### PR TITLE
fix: Exclude linux ARM from the build list, because Arrow doesn't support it in the matrix.

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -6,7 +6,15 @@ package main
 import (
 	// mage:import
 	build "github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/magefile/mage/mg"
 )
 
-// Default configures the default target.
-var Default = build.BuildAll
+// BuildAll is copied from Grafana's SDK (build package), because the Arrow
+// dependency doesn't support Linux ARM in the build matrix. I've removed it
+// from the listing here.
+func BuildIt() {
+	b := build.Build{}
+	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64)
+}
+
+var Default = BuildIt

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/apache/arrow/go/v10 v10.0.1
 	github.com/grafana/grafana-plugin-sdk-go v0.147.0
+	github.com/magefile/mage v1.14.0
 	google.golang.org/grpc v1.49.0
 )
 
@@ -41,7 +42,6 @@ require (
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
-	github.com/magefile/mage v1.14.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattetti/filebuffer v1.0.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect


### PR DESCRIPTION
I've copied some code over from the SDK and changed it to exclude this build target. This stops the errors from occurring when calling `mage -v`.