### PR TITLE
feat: Use FlightSQL API for table schema metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/apache/arrow/go/v10 v10.0.1
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/grafana/grafana-plugin-sdk-go v0.147.0
 	github.com/magefile/mage v1.14.0
 	google.golang.org/grpc v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/getkin/kin-openapi v0.94.0 h1:bAxg2vxgnHHHoeefVdmGbR+oxtJlcv5HsJJa3qm
 github.com/getkin/kin-openapi v0.94.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -40,10 +40,10 @@ export function BuilderView({query, datasource, onChange}: any) {
   useEffect(() => {
     ;(async () => {
       const res = await datasource.getColumns(table?.value)
-      const columns = res.frames[0].data.values[0].map((t: any) => ({
+      const columns = res.frames[0].schema.fields.map((t: any) => ({
         index: '',
-        label: t,
-        value: t,
+        label: t.name,
+        value: t.name,
       }))
       setColumns(columns)
     })()

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -59,7 +59,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
 
   const getTables = useCallback(async () => {
     const res = await datasource.getTables()
-    return res.frames[0].data.values[0].map((t: string) => ({
+    return res.frames[0].data.values[2].map((t: string) => ({
       name: t,
     }))
   }, [datasource])
@@ -67,9 +67,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const getColumns = useCallback(
     async (table: any) => {
       const res = await datasource.getColumns(table?.value)
-      return res.frames[0].data.values[0].map((c: any) => ({
-        name: c,
-      }))
+      return res.frames[0].schema.fields
     },
     [datasource]
   )

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -11,7 +11,7 @@ type AsyncTablesState = {
 export const GetTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
   const result = useAsync(async () => {
     const res = await datasource.getTables()
-    return res.frames[0].data.values[0].map((t: string) => ({
+    return res.frames[0].data.values[2].map((t: string) => ({
       label: t,
       value: t,
     }))


### PR DESCRIPTION
I've replaced `CommandStatementQuery` calls with equivalent Flight SQL metadata calls. Getting the tables and columns both use `CommandGetTables` under the hood. I've also added—for later—a `CommandGetSqlInfo` resource handler.