### PR TITLE
chore: Adjustments to the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ e2e-results/
 .idea
 
 .eslintcache
+
+grafana-flightsql-datasource*.tar.gz

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,53 @@
+# Developing the Plugin
+
+These instructions assume you have the following tools installed:
+
+- [`yarn`](https://yarnpkg.com)
+- [`mage`](https://magefile.org)
+
+## Frontend
+
+1. Install dependencies:
+
+   ```shell
+   $ yarn install
+   ```
+
+1. Build plugin in development mode:
+
+   ```shell
+   $ yarn dev
+   ```
+
+1. Run the linter prior to merging commits:
+
+   ```shell
+   $ yarn lint:fix
+   ```
+
+## Backend
+
+1. Build backend plugin binaries for Linux, Windows and Darwin:
+
+   ```shell
+   $ mage -v
+   ```
+
+   :warning: Mage has been configured **not** build the `linux-arm` target, because the
+   Apache Arrow project doesn't provide it in its build matrix.
+
+1. List all available Mage targets for additional commands:
+
+   ```shell
+   $ mage -l
+   ```
+
+1. Run the plugin using Docker Compose:
+
+   ```shell
+   $ yarn server
+   ```
+
+1. Navigate to the [Locally Running Grafana](http://localhost:3000/).
+1. Follow the instructions in [Adding a Flight SQL
+   Datasource](/#adding-a-flight-sql-datasource).

--- a/README.md
+++ b/README.md
@@ -1,140 +1,119 @@
 # Grafana Flight SQL Datasource
 
-⚠️ This library is experimental and under active development. The configuration it provides could change at any time so use at your own risk.
+:warning: This library is experimental and under active development. The configuration it provides could change at any time so use at your own risk.
 
-## Running the plugin in Grafana using Docker compose
+This is a plugin for Grafana that enables queries to Flight SQL APIs.
 
-To run grafana using docker with this plugin loaded in run:
+## Installation
 
-1. To build the frontend and backend into dist:
+### Download a Release
 
-`yarn build-plugin`
+We haven't released any builds of this plugin yet. You'll need to clone the
+repository and build it from source using following the instructions as a guide.
 
-2. To run grafana using docker-compose mounting the dist directory which contains the plugin:
+### Building from Source
 
-`yarn server`
+These instructions assume you have the following tools installed:
 
-3. Navigate to [Grafana homepage](http://localhost:3000/) and locate the FlightSQL datasource.
+- [`yarn`](https://yarnpkg.com)
+- [`mage`](https://magefile.org)
 
-## Running the plugin not using Docker
+#### Docker Compose
 
-1. To build the frontend and backend into dist:
+Docker Compose is the easiest way to get a Grafana instance running with this
+plugin present. A Docker Compose workflow is baked into the `yarn` workflow.
 
-`yarn build-plugin`
+1. Build frontend and backend in `dist/`:
 
-2. Make a zipfile of the plugin:
+   ```shell
+   $ yarn build-plugin
+   ```
+1. Start Grafana in Docker Compose:
 
-`zip grafana-flightsql-datasource-1.0.0.zip dist -r`
+   ```shell
+   $ yarn server
+   ```
+   The artifacts in `dist/` will be mounted and loaded into the installation.
 
-3. Unpack the plugin in your chosen directory eg `/Users/myusername/grafana-plugins/` and point your `grafana.ini` paths configuration at it:
+1. Navigate to the [Locally Running Grafana](http://localhost:3000/).
+1. Follow the instructions in [Adding a Flight SQL
+   Datasource](#adding-a-flight-sql-datasource).
 
-```
-[paths]
-plugins = /Users/myusername/grafana-plugins/
-```
+#### Running without Docker
 
-OR you will need to set the relevant environment variable:
+1. Build frontend and backend to produce `grafana-flightsql-datasource.tar.gz`:
 
-`GF_PATHS_PLUGINS=/Users/myusername/grafana-plugins/`
+   ```shell
+   $ yarn build-plugin
+   ```
+   
+1. Unpack the archive to your chosen directory (e.g. `grafana-plugins/`).
 
-4. The plugin is not yet signed so you will need to add it to the grafana configuration of allowed unsigned plugins: `grafana.ini`:
+   ```shell
+   $ mkdir -p grafana-plugins/grafana-flightsql-datasource
+   $ tar -xf grafana-flightsql-datasource.tar.gz -C grafana-plugins/grafana-flightsql-datasource
+   ```
+1. Point Grafana to this the plugins directory. You have two options:
 
-```
-[plugins]
-allow_loading_unsigned_plugins = grafana-flightsql-datasource
-```
+   - Edit the `paths.plugins` directive in your `grafana.ini`:
+     ```ini
+     [paths]
+     plugins = grafana-plugins/
+     ```
 
-OR you will need to set the relevant environment variable:
+   - **OR** set the relevant environment variable where Grafana is started:
+     ```shell
+     GF_PATHS_PLUGINS=grafana-plugins/
+     ```
 
-`GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-flightsql-datasource`
+1. The plugin is not yet signed so you will need to add it to the Grafana configuration of allowed unsigned plugins.
 
-5. Restart your grafana configuration
+   - Add the following to your `grafana.ini`:
+     ```ini
+     [plugins]
+     allow_loading_unsigned_plugins = grafana-flightsql-datasource
+     ```
+	
+	- **OR** set the relevant environment variable where Grafana is started:
+	  ```shell
+	  GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-flightsql-datasource
+	  ```
 
-6. Navigate to the Grafana homepage and locate the FlightSQL datasource.
+1. Navigate to the [Locally Running Grafana](http://localhost:3000/).
+1. Follow the instructions in [Adding a Flight SQL
+   Datasource](#adding-a-flight-sql-datasource).
 
-Further documentation about grafana configuration can be found [here](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins)
+:book: Further documentation about [Grafana configuration](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins).
 
-## Configuring the plugin:
+## Usage
 
-For specific IOX connectivity documentation go to our wiki [here](https://github.com/influxdata/grafana-flightsql-datasource/wiki).
+### Adding a Flight SQL Datasource
 
-- Host: Provide the host:port of your FlightSQL client.
+TODO
 
-- Database: Provide your target database name.
+### Configuring the Plugin
 
-- Token: Provide a bearer token for accessing your client.
-
-- Require TLS / SSL: Either enable or disable TLS based on the configuration of your client.
+- **Host:** Provide the host:port of your Flight SQL client.
+- **Database:** Provide your target database name.
+- **Token:** Provide a bearer token for accessing your client.
+- **Require TLS/SSL:** Either enable or disable TLS based on the configuration of your client.
 
 A username/password option is under active development.
 
-## Using the query builder
+Vendor-specific connectivity documentation can be [found in the wiki](https://github.com/influxdata/grafana-flightsql-datasource/wiki).
+
+### Using the Query Builder
 
 The default view is a query builder which is in active development:
 
 - Begin by selecting the table from the dropdown.
-
-- This will auto populate your available columns for your select statement. Use the + and - buttons to add or remove additional where statements.
-
-- You can overwrite a dropdown field by typing in your desired value eg `*`.
-
+- This will auto populate your available columns for your select statement. Use the **+** and **-** buttons to add or remove additional where statements.
+- You can overwrite a dropdown field by typing in your desired value (e.g. `*`).
 - The where field is a text entry where you can define any where clauses. Use the + and - buttons to add or remove additional where statements.
-
-- You can switch to a raw sql input by pressing the Edit SQL button this will show you the query you have been building thus far and allow you to enter any query.
-
-- Select the query button to see your results.
-
+- You can switch to a raw SQL input by pressing the "Edit SQL" button. This will show you the query you have been building thus far and allow you to enter any query.
+- Press the "Run query" button to see your results.
 - From there you can add to dashboards and create any additional dashboards you like.
 
-## Developing against the plugin
+## Development
 
-### Frontend setup
-
-1. Install dependencies
-
-   `yarn install`
-
-2. Build plugin in development mode
-
-   `yarn dev`
-
-3. Run the linter prior to merging commits
-
-   `yarn lint:fix`
-
-### Backend setup
-
-1. Update [Grafana plugin SDK for Go](https://grafana.com/docs/grafana/latest/developers/plugins/backend/grafana-plugin-sdk-for-go/) dependency to the latest minor version:
-
-   ```
-   go get -u github.com/grafana/grafana-plugin-sdk-go
-   go mod tidy
-   ```
-
-2. Build backend plugin binaries for Linux, Windows and Darwin:
-
-   `mage -v`
-
-3. List all available Mage targets for additional commands:
-
-   `mage -l`
-
-4. Run the plugin using docker:
-
-   `yarn server`
-
-Navigate to [Grafana homepage](http://localhost:3000/) and locate the FlightSQL datasource.
-
-## Grafana file structure
-
-plugin.json - defines capabilities of plugin - ie that it's a backend datasource
-
-module.ts - entrypoint for plugin wraps up - DataSourcePlugin
-
-src/components/ConfigEditor.tsx - connection to datasource
-
-src/components/QueryEditor.tsx - query ui feature set
-
-pkg/plugin/main.go - entrypoint into backend
-
-pkg/plugin/datasource.go - backend logic
+See [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "build-plugin": "yarn install --pure-lockfile && yarn build && mage -v",
+    "build-plugin": "yarn install --pure-lockfile && yarn build && mage -v && pushd dist && tar -czvf ../grafana-flightsql-datasource.tar.gz * && popd",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4 --passWithNoTests",


### PR DESCRIPTION
- Introduced a `DEVELOPMENT.md` file to capture some development specifics
- Moved InfluxDB IOx instructions to a dedicated page in the Wiki and linked to it under a vendor-specific section in the main page.
- Changed `yarn build-plugin` to produce a `grafana-flightsql-datasource.tar.gz` archive and expanded the instructions to capture how to expand that archive in the correct location (for the non-Docker setup).
- General hygiene in the README to reflect minor bumps I hit while going through the motions of setup.