### PR TITLE
fix: add note about current min grafana version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ These instructions assume you have the following tools installed:
 
 - [`yarn`](https://yarnpkg.com)
 - [`mage`](https://magefile.org)
+- [`grafana version 9.2.x`](https://grafana.com/grafana/download/9.2.0)
 
 #### Docker Compose
 


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/46