### PR TITLE
feat: dockerfile for custom grafana image including plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM grafana/grafana:latest
+
+ENV GF_AUTH_DISABLE_LOGIN_FORM "true"
+
+ENV GF_AUTH_ANONYMOUS_ENABLED "true"
+
+ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
+
+ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-flightsql-datasource
+
+ADD ./dist /var/lib/grafana/plugins/grafana-flightsql-datasource
+
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:latest
+FROM grafana/grafana:9.2.5
 
 ENV GF_AUTH_DISABLE_LOGIN_FORM "true"
 
@@ -9,5 +9,3 @@ ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
 ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-flightsql-datasource
 
 ADD ./dist /var/lib/grafana/plugins/grafana-flightsql-datasource
-
-EXPOSE 3000


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/56

Custom docker image for if someone needs a unsigned grafana docker image that includes our plugin

`docker build -t custom-grafana .`
`docker run -p 3000:3000 custom-grafana`
