### PR TITLE
feat: swap databased config for dynamic meta data input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ plugin present. A Docker Compose workflow is baked into the `yarn` workflow.
    ```shell
    $ yarn build-plugin
    ```
+
 1. Start Grafana in Docker Compose:
 
    ```shell
    $ yarn server
    ```
+
    The artifacts in `dist/` will be mounted and loaded into the installation.
 
 1. Navigate to the [Locally Running Grafana](http://localhost:3000/).
@@ -47,16 +49,18 @@ plugin present. A Docker Compose workflow is baked into the `yarn` workflow.
    ```shell
    $ yarn build-plugin
    ```
-   
+
 1. Unpack the archive to your chosen directory (e.g. `grafana-plugins/`).
 
    ```shell
    $ mkdir -p grafana-plugins/influxdata-flightsql-datasource
    $ tar -xf influxdata-flightsql-datasource.tar.gz -C grafana-plugins/influxdata-flightsql-datasource
    ```
+
 1. Point Grafana to this the plugins directory. You have two options:
 
    - Edit the `paths.plugins` directive in your `grafana.ini`:
+
      ```ini
      [paths]
      plugins = grafana-plugins/
@@ -70,15 +74,16 @@ plugin present. A Docker Compose workflow is baked into the `yarn` workflow.
 1. The plugin is not yet signed so you will need to add it to the Grafana configuration of allowed unsigned plugins.
 
    - Add the following to your `grafana.ini`:
+
      ```ini
      [plugins]
      allow_loading_unsigned_plugins = influxdata-flightsql-datasource
      ```
-	
-	- **OR** set the relevant environment variable where Grafana is started:
-	  ```shell
-	  GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=influxdata-flightsql-datasource
-	  ```
+
+   - **OR** set the relevant environment variable where Grafana is started:
+     ```shell
+     GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=influxdata-flightsql-datasource
+     ```
 
 1. Navigate to the [Locally Running Grafana](http://localhost:3000/).
 1. Follow the instructions in [Adding a Flight SQL
@@ -95,11 +100,12 @@ TODO
 ### Configuring the Plugin
 
 - **Host:** Provide the host:port of your Flight SQL client.
-- **Database:** Provide your target database name.
-- **Token:** Provide a bearer token for accessing your client.
+- **AuthType** Select between none, username/password and token.
+- **Token:** If auth type is token provide a bearer token for accessing your client.
+- **Username/Password** iF auth type is username and password provide a username and password.
 - **Require TLS/SSL:** Either enable or disable TLS based on the configuration of your client.
 
-A username/password option is under active development.
+- **MetaData** Provide optional key, value pairs that you need sent to your Flight SQL client.
 
 Vendor-specific connectivity documentation can be [found in the wiki](https://github.com/influxdata/grafana-flightsql-datasource/wiki).
 

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -24,12 +24,9 @@ var (
 	_ backend.CallResourceHandler   = (*FlightSQLDatasource)(nil)
 )
 
-const mdBucketName = "bucket-name"
-
 type config struct {
 	Addr     string            `json:"host"`
-	Database string            `json:"database"`
-	Metadata map[string]string `json:"metadata"`
+	Metadata []map[string]string `json:"metadata"`
 	Secure   bool              `json:"secure"`
 	Username string            `json:"username"`
 	Password string            `json:"password"`
@@ -39,9 +36,6 @@ type config struct {
 func (cfg config) validate() error {
 	if strings.Count(cfg.Addr, ":") == 0 {
 		return fmt.Errorf(`server address must be in the form "host:port"`)
-	}
-	if len(cfg.Database) == 0 {
-		return fmt.Errorf("database name is required")
 	}
 
 	noToken := len(cfg.Token) == 0
@@ -56,7 +50,6 @@ func (cfg config) validate() error {
 
 // FlightSQLDatasource is a Grafana datasource plugin for Flight SQL.
 type FlightSQLDatasource struct {
-	database        string
 	client          *flightsql.Client
 	resourceHandler backend.CallResourceHandler
 	md              metadata.MD
@@ -65,10 +58,12 @@ type FlightSQLDatasource struct {
 // NewDatasource creates a new datasource instance.
 func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	var cfg config
+
 	err := json.Unmarshal(settings.JSONData, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("config: %s", err)
 	}
+
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("config validation: %v", err)
 	}
@@ -77,13 +72,13 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	if err != nil {
 		return nil, fmt.Errorf("flightsql: %s", err)
 	}
-
+	
 	md := metadata.MD{}
-	for k, v := range cfg.Metadata {
-		md.Set(k, v)
-	}
-	// TODO(brett): Remove when the UI is completely configurable via metadata.
-	md.Set(mdBucketName, cfg.Database)
+	for _, m := range cfg.Metadata {
+        for k, v := range m {
+			md.Set(k, v)
+        }
+    }
 
 	ctx := context.Background()
 	if len(cfg.Username) > 0 || len(cfg.Password) > 0 {
@@ -98,7 +93,6 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	}
 
 	ds := &FlightSQLDatasource{
-		database: cfg.Database,
 		client:   client,
 		md:       md,
 	}

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -25,12 +25,12 @@ var (
 )
 
 type config struct {
-	Addr     string            `json:"host"`
+	Addr     string              `json:"host"`
 	Metadata []map[string]string `json:"metadata"`
-	Secure   bool              `json:"secure"`
-	Username string            `json:"username"`
-	Password string            `json:"password"`
-	Token    string            `json:"token"`
+	Secure   bool                `json:"secure"`
+	Username string              `json:"username"`
+	Password string              `json:"password"`
+	Token    string              `json:"token"`
 }
 
 func (cfg config) validate() error {
@@ -72,13 +72,16 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	if err != nil {
 		return nil, fmt.Errorf("flightsql: %s", err)
 	}
-	
+
 	md := metadata.MD{}
 	for _, m := range cfg.Metadata {
-        for k, v := range m {
+		for k, v := range m {
+			if _, ok := md[k]; ok {
+				return nil, fmt.Errorf("metadata: duplicate key: %s", k)
+			}
 			md.Set(k, v)
-        }
-    }
+		}
+	}
 
 	ctx := context.Background()
 	if len(cfg.Username) > 0 || len(cfg.Password) > 0 {
@@ -93,8 +96,8 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	}
 
 	ds := &FlightSQLDatasource{
-		client:   client,
-		md:       md,
+		client: client,
+		md:     md,
 	}
 	r := chi.NewRouter()
 	r.Use(recoverer)

--- a/pkg/flightsql/flightsql_test.go
+++ b/pkg/flightsql/flightsql_test.go
@@ -27,7 +27,6 @@ func TestQueryData(t *testing.T) {
 
 	cfg := config{
 		Addr:     server.Addr().String(),
-		Database: "sample",
 		Token:    "secret",
 		Secure:   false,
 	}

--- a/src/README.md
+++ b/src/README.md
@@ -2,15 +2,4 @@
 
 # FlightSQL
 
-Clone the repo:
-
-From this repo run: docker-compose up --build this will run grafana with the FlightSQL plugin loaded.
-
-Navigate to localhost:3000 and search in datasources for FlightSQL
-
-Configure your connection:
-
-Host:
-Database:
-Token:
-SSL mode:
+TODO:

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -4,7 +4,7 @@ import {css} from '@emotion/css'
 import {Select, SegmentSection, InlineLabel, Input} from '@grafana/ui'
 import {SelectableValue} from '@grafana/data'
 import {
-  getTables,
+  GetTables,
   checkCasing,
   buildQueryString,
   handleColumnChange,
@@ -31,7 +31,7 @@ export function BuilderView({query, datasource, onChange}: any) {
   const [table, setTable] = useState<SelectableValue<string>>()
   const [column, setColumn] = useState<SelectableValue<string>>()
 
-  const {loadingTable, tables, errorTable} = getTables(datasource)
+  const {loadingTable, tables, errorTable} = GetTables(datasource)
 
   useEffect(() => {
     ;(async () => {

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,79 +1,24 @@
-import React, {ChangeEvent, useEffect, useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {InlineSwitch, FieldSet, InlineField, SecretInput, Input, Select, InlineFieldRow} from '@grafana/ui'
 import {DataSourcePluginOptionsEditorProps, SelectableValue} from '@grafana/data'
-import {FlightSQLDataSourceOptions} from '../types'
+import {FlightSQLDataSourceOptions, authTypeOptions} from '../types'
+import {
+  onHostChange,
+  onDatabaseChange,
+  onTokenChange,
+  onSecureChange,
+  onUsernameChange,
+  onPasswordChange,
+  onAuthTypeChange,
+} from './utils'
 
 export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQLDataSourceOptions>) {
-  const onHostChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      host: event.target.value,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-
-  const onDatabaseChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      database: event.target.value,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-
-  const onTokenChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      token: event.target.value,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-
-  const onSecureChange = () => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      secure: !options.jsonData.secure,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-
-  const onUsernameChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      username: event.target.value,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-
-  const onPasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      password: event.target.value,
-    }
-    onOptionsChange({...options, jsonData})
-  }
-  const authTypeOptions = [
-    {key: 0, label: 'none', title: 'none'},
-    {key: 1, label: 'username/password', title: 'username/password'},
-    {key: 2, label: 'token', title: 'token'},
-  ]
+  const {options, onOptionsChange} = props
+  const {jsonData} = options
   const [selectedAuthType, setAuthType] = useState<SelectableValue<string>>(authTypeOptions[2])
-  const onAuthTypeChange = () => {
-    const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      selectedAuthType: selectedAuthType?.label,
-    }
-    onOptionsChange({...options, jsonData})
-  }
 
   useEffect(() => {
-    onAuthTypeChange()
+    onAuthTypeChange(selectedAuthType, options, onOptionsChange)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedAuthType])
 
@@ -88,9 +33,6 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const {options} = props
-  const {jsonData} = options
-
   return (
     <div>
       <FieldSet label="FlightSQL Connection" width={400}>
@@ -101,7 +43,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
             type="text"
             value={jsonData.host || ''}
             placeholder="localhost:1234"
-            onChange={onHostChange}
+            onChange={(e) => onHostChange(e, options, onOptionsChange)}
           ></Input>
         </InlineField>
 
@@ -111,7 +53,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
             name="database"
             type="text"
             placeholder="dbName"
-            onChange={onDatabaseChange}
+            onChange={(e) => onDatabaseChange(e, options, onOptionsChange)}
             value={jsonData.database || ''}
           ></Input>
         </InlineField>
@@ -135,8 +77,8 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
               type="text"
               value={jsonData.token || ''}
               placeholder="****************"
-              onChange={onTokenChange}
-              onReset={() => {}}
+              onChange={(e) => onTokenChange(e, options, onOptionsChange)}
+              onReset={() => onTokenChange(null, options, onOptionsChange)}
               isConfigured={false}
             ></SecretInput>
           </InlineField>
@@ -149,7 +91,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
                 name="username"
                 type="text"
                 placeholder="username"
-                onChange={onUsernameChange}
+                onChange={(e) => onUsernameChange(e, options, onOptionsChange)}
                 value={jsonData.username || ''}
               ></Input>
             </InlineField>
@@ -160,8 +102,8 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
                 type="text"
                 value={jsonData.password || ''}
                 placeholder="****************"
-                onChange={onPasswordChange}
-                onReset={() => {}}
+                onChange={(e) => onPasswordChange(e, options, onOptionsChange)}
+                onReset={() => onPasswordChange(null, options, onOptionsChange)}
                 isConfigured={false}
               ></SecretInput>
             </InlineField>
@@ -169,7 +111,13 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
         )}
 
         <InlineField labelWidth={20} label="Require TLS / SSL">
-          <InlineSwitch label="" value={jsonData.secure} onChange={onSecureChange} showLabel={false} disabled={false} />
+          <InlineSwitch
+            label=""
+            value={jsonData.secure}
+            onChange={() => onSecureChange(options, onOptionsChange)}
+            showLabel={false}
+            disabled={false}
+          />
         </InlineField>
       </FieldSet>
     </div>

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,22 +1,25 @@
 import React, {useEffect, useState} from 'react'
-import {InlineSwitch, FieldSet, InlineField, SecretInput, Input, Select, InlineFieldRow} from '@grafana/ui'
+import {InlineSwitch, FieldSet, InlineField, SecretInput, Input, Select, InlineFieldRow, InlineLabel} from '@grafana/ui'
 import {DataSourcePluginOptionsEditorProps, SelectableValue} from '@grafana/data'
 import {FlightSQLDataSourceOptions, authTypeOptions} from '../types'
 import {
   onHostChange,
-  onDatabaseChange,
   onTokenChange,
   onSecureChange,
   onUsernameChange,
   onPasswordChange,
   onAuthTypeChange,
+  onKeyChange,
+  onValueChange,
+  addMetaData,
+  removeMetaData,
 } from './utils'
 
 export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQLDataSourceOptions>) {
   const {options, onOptionsChange} = props
   const {jsonData} = options
   const [selectedAuthType, setAuthType] = useState<SelectableValue<string>>(authTypeOptions[2])
-
+  const [metaDataArr, setMetaData] = useState([{key: '', value: ''}])
   useEffect(() => {
     onAuthTypeChange(selectedAuthType, options, onOptionsChange)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -28,10 +31,22 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
       ...options.jsonData,
       selectedAuthType: 'token',
       secure: true,
+      metaDataArr: [{key: '', value: ''}],
     }
     onOptionsChange({...options, jsonData})
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    const {onOptionsChange, options} = props
+    const mapData = metaDataArr.map((m) => ({[m.key]: m.value}))
+    const jsonData = {
+      ...options.jsonData,
+      metaDataArr: mapData,
+    }
+    onOptionsChange({...options, jsonData})
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metaDataArr])
 
   return (
     <div>
@@ -44,17 +59,6 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
             value={jsonData.host || ''}
             placeholder="localhost:1234"
             onChange={(e) => onHostChange(e, options, onOptionsChange)}
-          ></Input>
-        </InlineField>
-
-        <InlineField labelWidth={20} label="Database">
-          <Input
-            width={40}
-            name="database"
-            type="text"
-            placeholder="dbName"
-            onChange={(e) => onDatabaseChange(e, options, onOptionsChange)}
-            value={jsonData.database || ''}
           ></Input>
         </InlineField>
         <InlineField labelWidth={20} label="Auth Type">
@@ -84,7 +88,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
           </InlineField>
         )}
         {selectedAuthType?.label === 'username/password' && (
-          <InlineFieldRow>
+          <InlineFieldRow style={{flexFlow: 'row'}}>
             <InlineField labelWidth={20} label="Username">
               <Input
                 width={40}
@@ -119,6 +123,49 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
             disabled={false}
           />
         </InlineField>
+      </FieldSet>
+      <FieldSet label="MetaData" width={400}>
+        {metaDataArr?.map((_: any, i: any) => (
+          <InlineFieldRow style={{flexFlow: 'row'}}>
+            <InlineField labelWidth={20} label="Key">
+              <Input
+                key={i}
+                width={40}
+                name="something"
+                type="text"
+                value={metaDataArr[i].key || ''}
+                placeholder="something"
+                onChange={(e) => onKeyChange(e, options, onOptionsChange, metaDataArr, i, setMetaData)}
+              ></Input>
+            </InlineField>
+            <InlineField labelWidth={20} label="Value">
+              <Input
+                key={i}
+                width={40}
+                name="something"
+                type="text"
+                value={metaDataArr[i].value || ''}
+                placeholder="something"
+                onChange={(e) => onValueChange(e, options, onOptionsChange, metaDataArr, i, setMetaData)}
+              ></Input>
+            </InlineField>
+            {i + 1 >= metaDataArr.length && (
+              <InlineLabel as="button" className="" onClick={() => addMetaData(setMetaData, metaDataArr)} width="auto">
+                +
+              </InlineLabel>
+            )}
+            {i > 0 && (
+              <InlineLabel
+                as="button"
+                className=""
+                width="auto"
+                onClick={() => removeMetaData(i, setMetaData, metaDataArr)}
+              >
+                -
+              </InlineLabel>
+            )}
+          </InlineFieldRow>
+        ))}
       </FieldSet>
     </div>
   )

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -31,7 +31,6 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
       ...options.jsonData,
       selectedAuthType: 'token',
       secure: true,
-      metaDataArr: [{key: '', value: ''}],
     }
     onOptionsChange({...options, jsonData})
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -42,7 +41,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
     const mapData = metaDataArr.map((m) => ({[m.key]: m.value}))
     const jsonData = {
       ...options.jsonData,
-      metaDataArr: mapData,
+      metadata: mapData,
     }
     onOptionsChange({...options, jsonData})
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -126,15 +125,15 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
       </FieldSet>
       <FieldSet label="MetaData" width={400}>
         {metaDataArr?.map((_: any, i: any) => (
-          <InlineFieldRow style={{flexFlow: 'row'}}>
+          <InlineFieldRow key={i} style={{flexFlow: 'row'}}>
             <InlineField labelWidth={20} label="Key">
               <Input
                 key={i}
                 width={40}
-                name="something"
+                name="key"
                 type="text"
                 value={metaDataArr[i].key || ''}
-                placeholder="something"
+                placeholder="key"
                 onChange={(e) => onKeyChange(e, options, onOptionsChange, metaDataArr, i, setMetaData)}
               ></Input>
             </InlineField>
@@ -142,10 +141,10 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
               <Input
                 key={i}
                 width={40}
-                name="something"
+                name="value"
                 type="text"
                 value={metaDataArr[i].value || ''}
-                placeholder="something"
+                placeholder="value"
                 onChange={(e) => onValueChange(e, options, onOptionsChange, metaDataArr, i, setMetaData)}
               ></Input>
             </InlineField>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,42 +1,20 @@
 import React, {useState, useMemo, useCallback, useEffect} from 'react'
 import {Button, Modal} from '@grafana/ui'
 import {QueryEditorProps} from '@grafana/data'
+import {MacroType} from '@grafana/experimental'
 import {FlightSQLDataSource} from '../datasource'
-import {FlightSQLDataSourceOptions, SQLQuery} from '../types'
+import {FlightSQLDataSourceOptions, SQLQuery, sqlLanguageDefinition} from '../types'
+import {getSqlCompletionProvider} from './utils'
 
 import {QueryEditorRaw} from './QueryEditorRaw'
-import {LanguageCompletionProvider, getStandardSQLCompletionProvider, MacroType} from '@grafana/experimental'
-import {formatSQL} from './sqlFormatter'
 import {BuilderView} from './BuilderView'
-
-export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider =
-  ({getTables, getColumns, sqlInfo, macros}) =>
-  (monaco, language) => {
-    return {
-      ...(language &&
-        getStandardSQLCompletionProvider(monaco, {
-          ...language,
-          builtinFunctions: sqlInfo.builtinFunctions,
-          keywords: sqlInfo.keywords,
-        })),
-      triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
-      tables: {
-        resolve: () => {
-          return getTables()
-        },
-      },
-      columns: {
-        resolve: (t: string) => getColumns(t),
-      },
-      supportedMacros: () => macros,
-    }
-  }
 
 export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuery, FlightSQLDataSourceOptions>) {
   const {onChange, query, datasource} = props
   const [isExpanded, setIsExpanded] = useState(false)
   const [sqlInfo, setSqlInfo] = useState<any>()
   const [macros, setMacros] = useState<any>()
+  const [builderView, setView] = useState(true)
 
   useEffect(() => {
     ;(async () => {
@@ -60,8 +38,6 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
       setMacros(macros)
     })()
   }, [datasource])
-
-  const [builderView, setView] = useState(true)
 
   const getTables = useCallback(async () => {
     const res = await datasource.getTables()
@@ -91,11 +67,6 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
       }),
     [getTables, getColumns, sqlInfo, macros]
   )
-
-  const sqlLanguageDefinition = {
-    id: 'sql',
-    formatter: formatSQL,
-  }
 
   return (
     <>

--- a/src/components/QueryEditorRaw.tsx
+++ b/src/components/QueryEditorRaw.tsx
@@ -1,20 +1,18 @@
 import {css} from '@emotion/css'
 import React, {useState} from 'react'
 import {useMeasure} from 'react-use'
-import AutoSizer from 'react-virtualized-auto-sizer'
-
 import {GrafanaTheme2} from '@grafana/data'
-import {Modal, useStyles2, useTheme2} from '@grafana/ui'
+import {Modal, useStyles2} from '@grafana/ui'
+import AutoSizer from 'react-virtualized-auto-sizer'
 
 import {RawEditor} from './RawEditor'
 import {QueryTool} from './QueryTool'
 
 export function QueryEditorRaw({onChange, query, editorLanguageDefinition}: any) {
-  const theme = useTheme2()
   const styles = useStyles2(getStyles)
   const [isExpanded, setIsExpanded] = useState(false)
   const [toolboxRef, toolboxMeasure] = useMeasure<HTMLDivElement>()
-  const [editorRef, editorMeasure] = useMeasure<HTMLDivElement>()
+  // const [editorRef, editorMeasure] = useMeasure<HTMLDivElement>()
 
   const renderQueryEditor = (width?: number, height?: number) => {
     return (
@@ -44,31 +42,12 @@ export function QueryEditorRaw({onChange, query, editorLanguageDefinition}: any)
         }}
       </AutoSizer>
     ) : (
-      <div ref={editorRef}>{renderQueryEditor()}</div>
+      <div>{renderQueryEditor()}</div>
     )
   }
-
-  const renderPlaceholder = () => {
-    return (
-      <div
-        style={{
-          width: editorMeasure.width,
-          height: editorMeasure.height,
-          background: theme.colors.background.primary,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        Editing in expanded code editor
-      </div>
-    )
-  }
-
   return (
     <>
-      {isExpanded ? renderPlaceholder() : renderEditor()}
-      {isExpanded && (
+      {isExpanded ? (
         <Modal
           title={`Query ${query.refId}`}
           closeOnBackdropClick={false}
@@ -82,6 +61,8 @@ export function QueryEditorRaw({onChange, query, editorLanguageDefinition}: any)
         >
           {renderEditor(true)}
         </Modal>
+      ) : (
+        renderQueryEditor()
       )}
     </>
   )

--- a/src/components/QueryEditorRaw.tsx
+++ b/src/components/QueryEditorRaw.tsx
@@ -12,7 +12,6 @@ export function QueryEditorRaw({onChange, query, editorLanguageDefinition}: any)
   const styles = useStyles2(getStyles)
   const [isExpanded, setIsExpanded] = useState(false)
   const [toolboxRef, toolboxMeasure] = useMeasure<HTMLDivElement>()
-  // const [editorRef, editorMeasure] = useMeasure<HTMLDivElement>()
 
   const renderQueryEditor = (width?: number, height?: number) => {
     return (

--- a/src/components/QueryTool.tsx
+++ b/src/components/QueryTool.tsx
@@ -1,7 +1,6 @@
-import {css} from '@emotion/css'
-import React, {useMemo} from 'react'
+import React from 'react'
 
-import {HorizontalGroup, IconButton, useTheme2, Tooltip, Icon} from '@grafana/ui'
+import {HorizontalGroup, IconButton, Tooltip, Icon} from '@grafana/ui'
 
 interface QueryToolProps {
   showTools?: boolean
@@ -10,67 +9,23 @@ interface QueryToolProps {
   onExpand?: (expand: boolean) => void
 }
 
-export function QueryTool({showTools, onFormatCode, onExpand, isExpanded}: QueryToolProps) {
-  const theme = useTheme2()
-
-  const styles = useMemo(() => {
-    return {
-      container: css`
-        border: 1px solid ${theme.colors.border.medium};
-        border-top: none;
-        padding: ${theme.spacing(0.5, 0.5, 0.5, 0.5)};
-        display: flex;
-        flex-grow: 1;
-        justify-content: space-between;
-        font-size: ${theme.typography.bodySmall.fontSize};
-      `,
-      error: css`
-        color: ${theme.colors.error.text};
-        font-size: ${theme.typography.bodySmall.fontSize};
-        font-family: ${theme.typography.fontFamilyMonospace};
-      `,
-      valid: css`
-        color: ${theme.colors.success.text};
-      `,
-      info: css`
-        color: ${theme.colors.text.secondary};
-      `,
-      hint: css`
-        color: ${theme.colors.text.disabled};
-        white-space: nowrap;
-        cursor: help;
-      `,
-    }
-  }, [theme])
-
-  let style = {}
-
-  if (!showTools) {
-    style = {height: 0, padding: 0, visibility: 'hidden'}
-  }
-
-  return (
-    <div className={styles.container} style={style}>
-      {showTools && (
-        <div>
-          <HorizontalGroup spacing="sm">
-            {onFormatCode && (
-              <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />
-            )}
-            {onExpand && (
-              <IconButton
-                onClick={() => onExpand(!isExpanded)}
-                name={isExpanded ? 'angle-up' : 'angle-down'}
-                size="xs"
-                tooltip={isExpanded ? 'Collapse editor' : 'Expand editor'}
-              />
-            )}
-            <Tooltip content="Hit CMD+Return to run query">
-              <Icon className="hint" name="keyboard" />
-            </Tooltip>
-          </HorizontalGroup>
-        </div>
-      )}
+export const QueryTool = ({onFormatCode, onExpand, isExpanded}: QueryToolProps) => (
+  <div className="none">
+    <div>
+      <HorizontalGroup spacing="sm">
+        {onFormatCode && <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />}
+        {onExpand && (
+          <IconButton
+            onClick={() => onExpand(!isExpanded)}
+            name={isExpanded ? 'angle-up' : 'angle-down'}
+            size="xs"
+            tooltip={isExpanded ? 'Collapse editor' : 'Expand editor'}
+          />
+        )}
+        <Tooltip content="Hit CMD+Return to run query">
+          <Icon className="hint" name="keyboard" />
+        </Tooltip>
+      </HorizontalGroup>
     </div>
-  )
-}
+  </div>
+)

--- a/src/components/SelectColumn.tsx
+++ b/src/components/SelectColumn.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import {Select} from '@grafana/ui'
 
 export const SelectColumn = ({columns, index, setColumn, columnValues, formatCreateLabel}: any) => (

--- a/src/components/WhereExp.tsx
+++ b/src/components/WhereExp.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-
 import {Input} from '@grafana/ui'
 
 export const WhereExp = ({index, setWhere, whereValues}: any) => (

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,6 +1,7 @@
 import {useAsync} from 'react-use'
 import {FlightSQLDataSource} from '../datasource'
 import {SelectableValue} from '@grafana/data'
+import {LanguageCompletionProvider, getStandardSQLCompletionProvider} from '@grafana/experimental'
 
 type AsyncTablesState = {
   loadingTable: boolean
@@ -8,7 +9,7 @@ type AsyncTablesState = {
   errorTable: Error | undefined
 }
 
-export const getTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
+export const GetTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
   const result = useAsync(async () => {
     const res = await datasource.getTables()
     return res.frames[0].data.values[2].map((t: string) => ({
@@ -109,3 +110,82 @@ export const formatWheres = (whereValues: any) => {
 }
 
 export const formatCreateLabel = (v: string) => v
+
+export const onHostChange = (event: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    host: event.target.value,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onDatabaseChange = (event: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    database: event.target.value,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onTokenChange = (event: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    token: event.target.value,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onSecureChange = (options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    secure: !options.jsonData.secure,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onUsernameChange = (event: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    username: event.target.value,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onPasswordChange = (event: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    password: event.target.value,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const onAuthTypeChange = (selectedAuthType: any, options: any, onOptionsChange: any) => {
+  const jsonData = {
+    ...options.jsonData,
+    selectedAuthType: selectedAuthType?.label,
+  }
+  onOptionsChange({...options, jsonData})
+}
+
+export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider =
+  ({getTables, getColumns, sqlInfo, macros}) =>
+  (monaco, language) => {
+    return {
+      ...(language &&
+        getStandardSQLCompletionProvider(monaco, {
+          ...language,
+          builtinFunctions: sqlInfo.builtinFunctions,
+          keywords: sqlInfo.keywords,
+        })),
+      triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
+      tables: {
+        resolve: () => {
+          return getTables()
+        },
+      },
+      columns: {
+        resolve: (t: string) => getColumns(t),
+      },
+      supportedMacros: () => macros,
+    }
+  }

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -189,3 +189,49 @@ export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider
       supportedMacros: () => macros,
     }
   }
+
+export const addMetaData = (setMetaData: any, metaDataArr: any) => {
+  setMetaData([...metaDataArr, {value: ''}])
+}
+
+export const removeMetaData = (i: any, setMetaData: any, metaDataArr: any) => {
+  let newMetaValues = [...metaDataArr]
+  newMetaValues.splice(i, 1)
+  setMetaData(newMetaValues)
+}
+
+export const onKeyChange = (
+  event: any,
+  options: any,
+  onOptionsChange: any,
+  metaDataArr: any,
+  index: any,
+  setMetaData: any
+) => {
+  let newMetaValues = [...metaDataArr]
+  newMetaValues[index]['key'] = event.target.value
+  const jsonData = {
+    ...options.jsonData,
+    metaDataArr: newMetaValues,
+  }
+  onOptionsChange({...options, jsonData})
+  setMetaData(newMetaValues)
+}
+
+export const onValueChange = (
+  event: any,
+  options: any,
+  onOptionsChange: any,
+  metaDataArr: any,
+  index: any,
+  setMetaData: any
+) => {
+  let newMetaValues = [...metaDataArr]
+  newMetaValues[index]['value'] = event.target.value
+  const jsonData = {
+    ...options.jsonData,
+    metaDataArr: newMetaValues,
+  }
+  onOptionsChange({...options, jsonData})
+  setMetaData(newMetaValues)
+}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -8,7 +8,7 @@ type AsyncTablesState = {
   errorTable: Error | undefined
 }
 
-export const GetTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
+export const getTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
   const result = useAsync(async () => {
     const res = await datasource.getTables()
     return res.frames[0].data.values[2].map((t: string) => ({
@@ -61,3 +61,51 @@ export const checkCasing = (str: string) => {
 
   return str
 }
+
+export const handleColumnChange = (column: any, setColumnValues: any, columnValues: any) => {
+  let newColumnValues = [...columnValues]
+  newColumnValues[column.index]['value'] = column.value
+  setColumnValues(newColumnValues)
+}
+
+export const addColumns = (setColumnValues: any, columnValues: any) => {
+  setColumnValues([...columnValues, {value: ''}])
+}
+
+export const removeColumns = (i: any, setColumnValues: any, columnValues: any) => {
+  let newColumnValues = [...columnValues]
+  newColumnValues.splice(i, 1)
+  setColumnValues(newColumnValues)
+}
+
+export const handleWhereChange = (where: any, setWhereValues: any, whereValues: any) => {
+  let newWhereValues = [...whereValues]
+  newWhereValues[where.index]['value'] = where.value
+  setWhereValues(newWhereValues)
+}
+
+export const addWheres = (setWhereValues: any, whereValues: any) => {
+  setWhereValues([...whereValues, {value: ''}])
+}
+
+export const removeWheres = (i: any, setWhereValues: any, whereValues: any) => {
+  let newWhereValues = [...whereValues]
+  newWhereValues.splice(i, 1)
+  setWhereValues(newWhereValues)
+}
+
+export const formatColumns = (columnArr: any) => {
+  return columnArr
+    .map((c: any) => checkCasing(c.value))
+    .join(',')
+    .replace(/,\s*$/, '')
+}
+
+export const formatWheres = (whereValues: any) => {
+  return whereValues
+    .map((w: any) => w.value)
+    .filter(Boolean)
+    .join(' and ')
+}
+
+export const formatCreateLabel = (v: string) => v

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -119,14 +119,6 @@ export const onHostChange = (event: any, options: any, onOptionsChange: any) => 
   onOptionsChange({...options, jsonData})
 }
 
-export const onDatabaseChange = (event: any, options: any, onOptionsChange: any) => {
-  const jsonData = {
-    ...options.jsonData,
-    database: event.target.value,
-  }
-  onOptionsChange({...options, jsonData})
-}
-
 export const onTokenChange = (event: any, options: any, onOptionsChange: any) => {
   const jsonData = {
     ...options.jsonData,
@@ -212,7 +204,7 @@ export const onKeyChange = (
   newMetaValues[index]['key'] = event.target.value
   const jsonData = {
     ...options.jsonData,
-    metaDataArr: newMetaValues,
+    metadata: newMetaValues,
   }
   onOptionsChange({...options, jsonData})
   setMetaData(newMetaValues)
@@ -230,7 +222,7 @@ export const onValueChange = (
   newMetaValues[index]['value'] = event.target.value
   const jsonData = {
     ...options.jsonData,
-    metaDataArr: newMetaValues,
+    metadata: newMetaValues,
   }
   onOptionsChange({...options, jsonData})
   setMetaData(newMetaValues)

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,6 +1,5 @@
 import {DataSourceInstanceSettings, CoreApp} from '@grafana/data'
 import {DataSourceWithBackend} from '@grafana/runtime'
-
 import {SQLQuery, FlightSQLDataSourceOptions, DEFAULT_QUERY} from './types'
 
 export class FlightSQLDataSource extends DataSourceWithBackend<SQLQuery, FlightSQLDataSourceOptions> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface FlightSQLDataSourceOptions extends DataSourceJsonData {
   username?: string
   password?: string
   selectedAuthType?: string
+  metaDataArr?: any
 }
 
 export type TablesResponse = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import {DataQuery, DataSourceJsonData} from '@grafana/data'
+import {formatSQL} from './components/sqlFormatter'
 
 export interface SQLQuery extends DataQuery {
   queryText?: string
@@ -25,4 +26,15 @@ export type TablesResponse = {
 
 export type ColumnsResponse = {
   columns: string[]
+}
+
+export const authTypeOptions = [
+  {key: 0, label: 'none', title: 'none'},
+  {key: 1, label: 'username/password', title: 'username/password'},
+  {key: 2, label: 'token', title: 'token'},
+]
+
+export const sqlLanguageDefinition = {
+  id: 'sql',
+  formatter: formatSQL,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,13 +12,12 @@ export const DEFAULT_QUERY: Partial<SQLQuery> = {}
  */
 export interface FlightSQLDataSourceOptions extends DataSourceJsonData {
   host?: string
-  database?: string
   token?: string
   secure?: boolean
   username?: string
   password?: string
   selectedAuthType?: string
-  metaDataArr?: any
+  metadata?: any
 }
 
 export type TablesResponse = {


### PR DESCRIPTION
- [x] now users can provide any meta data their flight sql client needs
- [x] instead of having a database field as default in the config we have a meta data field where bucket-name or bucket-id can be passed
- [x] updated [documentation](https://github.com/influxdata/grafana-flightsql-datasource/wiki/InfluxDB-IOx)
- [x] separate clean up of utils and types

closes https://github.com/influxdata/grafana-flightsql-datasource/issues/45


<img width="1172" alt="Screen Shot 2023-01-24 at 2 07 08 PM" src="https://user-images.githubusercontent.com/38860767/214389875-b34c6413-970d-433e-a7c4-065f7c8ca988.png">

