### PR TITLE
feat(query): Output format support

### DIFF
--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -45,11 +45,13 @@ func newQueryDataResponse(reader recordReader, query *sqlutil.Query) backend.Dat
 	case sqlutil.FormatOptionTimeSeries:
 		if _, idx := frame.FieldByName("time"); idx == -1 {
 			resp.Error = fmt.Errorf("no time column found")
+			return resp
 		}
 		var err error
 		frame, err = data.LongToWide(frame, nil)
 		if err != nil {
 			resp.Error = err
+			return resp
 		}
 	case sqlutil.FormatOptionTable:
 		// No changes to the output. Send it as is.

--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -47,11 +47,14 @@ func newQueryDataResponse(reader recordReader, query *sqlutil.Query) backend.Dat
 			resp.Error = fmt.Errorf("no time column found")
 			return resp
 		}
-		var err error
-		frame, err = data.LongToWide(frame, nil)
-		if err != nil {
-			resp.Error = err
-			return resp
+
+		if frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
+			var err error
+			frame, err = data.LongToWide(frame, nil)
+			if err != nil {
+				resp.Error = err
+				return resp
+			}
 		}
 	case sqlutil.FormatOptionTable:
 		// No changes to the output. Send it as is.

--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow/go/v10/arrow/scalar"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 )
 
 // TODO(brett): Make this configurable. This is an arbitrary value right
@@ -31,41 +32,32 @@ type recordReader interface {
 // [arrow.Record]s.
 //
 // The backend.DataResponse contains a single [data.Frame].
-func newQueryDataResponse(reader recordReader, sql string) backend.DataResponse {
+func newQueryDataResponse(reader recordReader, query *sqlutil.Query) backend.DataResponse {
 	var resp backend.DataResponse
 	frame, err := frameForRecords(reader)
 	if err != nil {
 		resp.Error = err
 	}
-	frame.Meta.ExecutedQueryString = sql
-	frame.Meta.DataTopic = data.DataTopic(sql)
+	frame.Meta.ExecutedQueryString = query.RawSQL
+	frame.Meta.DataTopic = data.DataTopic(query.RawSQL)
 
-	// If the data contains a `time` column of type `timestamp` and at least one
-	// column of type `string`, the resulting table will be converted to wide
-	// format.
-	//
-	// Data Frame Formatting Reference:
-	// - https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#wide-format
-	// - https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#long-format
-	var (
-		hasTimeField   bool
-		hasStringField bool
-		schema         = reader.Schema()
-	)
-	for _, f := range schema.Fields() {
-		if f.Name == "time" && f.Type.ID() == arrow.TIMESTAMP {
-			hasTimeField = true
-		} else if f.Type.ID() == arrow.STRING {
-			hasStringField = true
+	switch query.Format {
+	case sqlutil.FormatOptionTimeSeries:
+		if _, idx := frame.FieldByName("time"); idx == -1 {
+			resp.Error = fmt.Errorf("no time column found")
 		}
-	}
-	fmt.Println(hasTimeField, hasStringField)
-	if hasTimeField && hasStringField {
 		var err error
 		frame, err = data.LongToWide(frame, nil)
 		if err != nil {
 			resp.Error = err
 		}
+	case sqlutil.FormatOptionTable:
+		// No changes to the output. Send it as is.
+	case sqlutil.FormatOptionLogs:
+		// TODO(brett): We need to find out what this actually is and if its
+		// worth supporting. Pass through as "table" for now.
+	default:
+		resp.Error = fmt.Errorf("unsupported format")
 	}
 
 	resp.Frames = data.Frames{frame}

--- a/pkg/flightsql/arrow_test.go
+++ b/pkg/flightsql/arrow_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow/go/v10/arrow/memory"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,8 @@ func TestNewQueryDataResponse(t *testing.T) {
 	reader, err := array.NewRecordReader(schema, records)
 	require.NoError(t, err)
 
-	resp := newQueryDataResponse(errReader{RecordReader: reader}, "")
+	query := &sqlutil.Query{Format: sqlutil.FormatOptionTable}
+	resp := newQueryDataResponse(errReader{RecordReader: reader}, query)
 	require.NoError(t, resp.Error)
 	require.Len(t, resp.Frames, 1)
 	require.Len(t, resp.Frames[0].Fields, 2)
@@ -93,7 +95,8 @@ func TestNewQueryDataResponse_Error(t *testing.T) {
 		RecordReader: reader,
 		err:          fmt.Errorf("explosion!"),
 	}
-	resp := newQueryDataResponse(wrappedReader, "")
+	query := &sqlutil.Query{Format: sqlutil.FormatOptionTable}
+	resp := newQueryDataResponse(wrappedReader, query)
 	require.Error(t, resp.Error)
 	require.Equal(t, fmt.Errorf("explosion!"), resp.Error)
 }
@@ -133,7 +136,7 @@ func TestNewQueryDataResponse_WideTable(t *testing.T) {
 	reader, err := array.NewRecordReader(schema, records)
 	require.NoError(t, err)
 
-	resp := newQueryDataResponse(errReader{RecordReader: reader}, "")
+	resp := newQueryDataResponse(errReader{RecordReader: reader}, &sqlutil.Query{})
 	require.NoError(t, resp.Error)
 	require.Len(t, resp.Frames, 1)
 	require.Equal(t, 3, resp.Frames[0].Rows())

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -132,7 +133,8 @@ func (d *FlightSQLDatasource) CallResource(ctx context.Context, req *backend.Cal
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *FlightSQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	if resp := d.query(ctx, "select 1"); resp.Error != nil {
+	query := &sqlutil.Query{RawSQL: "select 1"}
+	if resp := d.query(ctx, query); resp.Error != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
 			Message: fmt.Sprintf("ERROR: %s", resp.Error),

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -133,7 +133,10 @@ func (d *FlightSQLDatasource) CallResource(ctx context.Context, req *backend.Cal
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *FlightSQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	query := &sqlutil.Query{RawSQL: "select 1"}
+	query := &sqlutil.Query{
+		RawSQL: "select 1",
+		Format: sqlutil.FormatOptionTable,
+	}
 	if resp := d.query(ctx, query); resp.Error != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,

--- a/pkg/flightsql/flightsql_test.go
+++ b/pkg/flightsql/flightsql_test.go
@@ -26,9 +26,9 @@ func TestQueryData(t *testing.T) {
 	defer server.Shutdown()
 
 	cfg := config{
-		Addr:     server.Addr().String(),
-		Token:    "secret",
-		Secure:   false,
+		Addr:   server.Addr().String(),
+		Token:  "secret",
+		Secure: false,
 	}
 	cfgJSON, err := json.Marshal(cfg)
 	require.NoError(t, err)
@@ -72,8 +72,9 @@ func mustQueryJSON(t *testing.T, refID, sql string) []byte {
 	t.Helper()
 
 	b, err := json.Marshal(queryRequest{
-		RefID: refID,
-		Text:  sql,
+		RefID:  refID,
+		Text:   sql,
+		Format: "table",
 	})
 	if err != nil {
 		panic(err)

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -115,6 +115,7 @@ export function BuilderView({query, datasource, onChange}: any) {
                   className=""
                   onClick={() => addColumns(setColumnValues, columnValues)}
                   width="auto"
+                  style={{marginLeft: '5px'}}
                 >
                   +
                 </InlineLabel>
@@ -143,8 +144,9 @@ export function BuilderView({query, datasource, onChange}: any) {
                 <InlineLabel
                   as="button"
                   className=""
-                  onClick={() => addWheres(whereValues, setWhereValues)}
+                  onClick={() => addWheres(setWhereValues, whereValues)}
                   width="auto"
+                  style={{marginLeft: '5px'}}
                 >
                   +
                 </InlineLabel>
@@ -154,7 +156,7 @@ export function BuilderView({query, datasource, onChange}: any) {
                   as="button"
                   className=""
                   width="auto"
-                  onClick={() => removeWheres(index, whereValues, setWhereValues)}
+                  onClick={() => removeWheres(index, setWhereValues, whereValues)}
                 >
                   -
                 </InlineLabel>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -123,20 +123,22 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
           }}
         />
       )}
-      <InlineFieldRow style={{flexFlow: 'row', alignItems: 'center'}}>
-        <SegmentSection label="Format As" fill={true}>
-          <Select
-            options={QUERY_FORMAT_OPTIONS}
-            onChange={setFormat}
-            value={query.format}
-            width={15}
-            placeholder="Table"
-          />
-        </SegmentSection>
-        <Button fill="outline" size="md" onClick={() => setIsExpanded(!isExpanded)}>
-          {builderView ? 'Edit SQL' : 'Builder View'}
-        </Button>
-      </InlineFieldRow>
+      <div style={{width: '100%'}}>
+        <InlineFieldRow style={{flexFlow: 'row', alignItems: 'center'}}>
+          <SegmentSection label="Format As" fill={false}>
+            <Select
+              options={QUERY_FORMAT_OPTIONS}
+              onChange={setFormat}
+              value={query.format}
+              width={15}
+              placeholder="Table"
+            />
+          </SegmentSection>
+          <Button style={{marginLeft: '5px'}} fill="outline" size="md" onClick={() => setIsExpanded(!isExpanded)}>
+            {builderView ? 'Edit SQL' : 'Builder View'}
+          </Button>
+        </InlineFieldRow>
+      </div>
     </>
   )
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,9 +1,9 @@
 import React, {useState, useMemo, useCallback, useEffect} from 'react'
-import {Button, Modal} from '@grafana/ui'
-import {QueryEditorProps} from '@grafana/data'
+import {Button, Modal, SegmentSection, Select, InlineFieldRow} from '@grafana/ui'
+import {QueryEditorProps, SelectableValue} from '@grafana/data'
 import {MacroType} from '@grafana/experimental'
 import {FlightSQLDataSource} from '../datasource'
-import {FlightSQLDataSourceOptions, SQLQuery, sqlLanguageDefinition} from '../types'
+import {FlightSQLDataSourceOptions, SQLQuery, sqlLanguageDefinition, QUERY_FORMAT_OPTIONS} from '../types'
 import {getSqlCompletionProvider} from './utils'
 
 import {QueryEditorRaw} from './QueryEditorRaw'
@@ -15,6 +15,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [sqlInfo, setSqlInfo] = useState<any>()
   const [macros, setMacros] = useState<any>()
   const [builderView, setView] = useState(true)
+  const [format, setFormat] = useState<SelectableValue<string>>()
 
   useEffect(() => {
     ;(async () => {
@@ -68,6 +69,15 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
     [getTables, getColumns, sqlInfo, macros]
   )
 
+  useEffect(() => {
+    onChange({...query, format: format?.value})
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [format])
+
+  useEffect(() => {
+    setFormat(QUERY_FORMAT_OPTIONS[1])
+  }, [])
+
   return (
     <>
       {isExpanded && (
@@ -113,9 +123,20 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
           }}
         />
       )}
-      <Button fill="outline" size="sm" onClick={() => setIsExpanded(!isExpanded)}>
-        {builderView ? 'Edit SQL' : 'Builder View'}
-      </Button>
+      <InlineFieldRow style={{flexFlow: 'row', alignItems: 'center'}}>
+        <SegmentSection label="Format As" fill={true}>
+          <Select
+            options={QUERY_FORMAT_OPTIONS}
+            onChange={setFormat}
+            value={query.format}
+            width={15}
+            placeholder="Table"
+          />
+        </SegmentSection>
+        <Button fill="outline" size="md" onClick={() => setIsExpanded(!isExpanded)}>
+          {builderView ? 'Edit SQL' : 'Builder View'}
+        </Button>
+      </InlineFieldRow>
     </>
   )
 }

--- a/src/components/QueryTool.tsx
+++ b/src/components/QueryTool.tsx
@@ -10,7 +10,7 @@ interface QueryToolProps {
 }
 
 export const QueryTool = ({onFormatCode, onExpand, isExpanded}: QueryToolProps) => (
-  <div className="none">
+  <div className="none" style={{padding: '5px 0'}}>
     <div>
       <HorizontalGroup spacing="sm">
         {onFormatCode && <IconButton onClick={onFormatCode} name="brackets-curly" size="xs" tooltip="Format query" />}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import {formatSQL} from './components/sqlFormatter'
 
 export interface SQLQuery extends DataQuery {
   queryText?: string
+  format?: string
 }
 
 export const DEFAULT_QUERY: Partial<SQLQuery> = {}
@@ -38,3 +39,13 @@ export const sqlLanguageDefinition = {
   id: 'sql',
   formatter: formatSQL,
 }
+
+export enum QueryFormat {
+  Timeseries = 'time_series',
+  Table = 'table',
+}
+
+export const QUERY_FORMAT_OPTIONS = [
+  {label: 'Time series', value: QueryFormat.Timeseries},
+  {label: 'Table', value: QueryFormat.Table},
+]


### PR DESCRIPTION
This adjusts the output format according to what the UI requests. A new `format` field has been introduced on the query payload that supports the following values: `table` and `time_series`.

When `time_series` is chosen we do a long-to-wide conversion to create the label series. `table` is just a direct passthrough of what we receive from the upstream.