### PR TITLE
feat(macros): Provide macros for range operations and simple from/to substitutions.

### DIFF
--- a/pkg/flightsql/macro.go
+++ b/pkg/flightsql/macro.go
@@ -13,6 +13,15 @@ var macros = sqlutil.Macros{
 	"interval":       macroInterval,
 	"timeGroup":      macroTimeGroup,
 	"timeGroupAlias": macroTimeGroupAlias,
+
+	// The behaviors of timeFrom and timeTo as defined in the SDK are different
+	// from all other Grafana SQL plugins. Instead we'll take their
+	// implementations, rename them and define timeFrom and timeTo ourselves.
+	"timeRangeFrom": sqlutil.DefaultMacros["timeFrom"],
+	"timeRangeTo":   sqlutil.DefaultMacros["timeTo"],
+	"timeRange":     sqlutil.DefaultMacros["timeFilter"],
+	"timeTo":        macroTo,
+	"timeFrom":      macroFrom,
 }
 
 func macroTimeGroup(query *sqlutil.Query, args []string) (string, error) {
@@ -76,11 +85,11 @@ func macroInterval(query *sqlutil.Query, _ []string) (string, error) {
 }
 
 func macroFrom(query *sqlutil.Query, _ []string) (string, error) {
-	return query.TimeRange.From.Format(time.RFC3339), nil
+	return fmt.Sprintf("cast('%s' as timestamp)", query.TimeRange.From.Format(time.RFC3339)), nil
 }
 
 func macroTo(query *sqlutil.Query, _ []string) (string, error) {
-	return query.TimeRange.To.Format(time.RFC3339), nil
+	return fmt.Sprintf("cast('%s' as timestamp)", query.TimeRange.To.Format(time.RFC3339)), nil
 }
 
 func macroDateBin(suffix string) sqlutil.MacroFunc {

--- a/pkg/flightsql/macro_test.go
+++ b/pkg/flightsql/macro_test.go
@@ -45,12 +45,24 @@ func TestMacros(t *testing.T) {
 			out: `select * from x where time >= '2023-01-01T00:00:00Z' AND time <= '2023-01-01T00:10:00Z'`,
 		},
 		{
-			in:  `select * from x where $__timeFrom(time)`,
+			in:  `select * from x where $__timeRangeFrom(time)`,
 			out: `select * from x where time >= '2023-01-01T00:00:00Z'`,
 		},
 		{
-			in:  `select * from x where $__timeTo(time)`,
+			in:  `select * from x where $__timeRangeTo(time)`,
 			out: `select * from x where time <= '2023-01-01T00:10:00Z'`,
+		},
+		{
+			in:  `select * from x where $__timeRange(time)`,
+			out: `select * from x where time >= '2023-01-01T00:00:00Z' AND time <= '2023-01-01T00:10:00Z'`,
+		},
+		{
+			in:  `select * from x where time >= $__timeFrom`,
+			out: `select * from x where time >= cast('2023-01-01T00:00:00Z' as timestamp)`,
+		},
+		{
+			in:  `select * from x where time < $__timeTo`,
+			out: `select * from x where time < cast('2023-01-01T00:10:00Z' as timestamp)`,
 		},
 	}
 	for _, c := range cs {


### PR DESCRIPTION
After reading through the MySQL and Postgres Grafana SQL plugins we noticed that `$__timeFrom` and `$__timeTo` are simple range boundary substitutions. However, the SDK is defining these as range operations. This is a move to conform to what users might already expect based on the norms of other plugins. Here are the new patterns:

```
$__timeRangeFrom(time)           time >= '2023-01-01T00:00:00Z'
$__timeRangeTo(time)             time <= '2023-01-01T01:00:00Z'
$__timeRange(time)               time >= '2023-01 01T00:00:00Z' and time <= '2023-01-01T01:00:00Z'
$__timeFrom() or $__timeFrom     cast('2023-01-01T00:00:00Z' as timestamp)
$__timeTo() or $__timeTo         cast('2023-01-01T01:00:00Z' as timestamp)
```

The `timeFrom` and `timeTo` macros are using a `cast` which should offer wider compatibility (ANSI) than `::` or naked string syntax.

`timeRangeTo` is inclusive, because it conforms with the behavior of `timeRange` and if you were to use SQL `BETWEEN` syntax.