### PR TITLE
feat: Support alerting

### DIFF
--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -38,6 +38,11 @@ func newQueryDataResponse(reader recordReader, query *sqlutil.Query) backend.Dat
 	if err != nil {
 		resp.Error = err
 	}
+	if frame.Rows() == 0 {
+		resp.Frames = data.Frames{}
+		return resp
+	}
+
 	frame.Meta.ExecutedQueryString = query.RawSQL
 	frame.Meta.DataTopic = data.DataTopic(query.RawSQL)
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,6 +5,7 @@
   "id": "influxdata-flightsql-datasource",
   "metrics": true,
   "backend": true,
+  "alerting": true,
   "executable": "gpx_flightsql_datasource",
   "info": {
     "description": "",


### PR DESCRIPTION
This includes a fix to return an empty frame-set if there are no rows to return. This keeps the alerting components from barking at us about long-vs-wide formats for input data.