### PR TITLE
feat: default to raw sql remove set format on load

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -14,7 +14,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [isExpanded, setIsExpanded] = useState(false)
   const [sqlInfo, setSqlInfo] = useState<any>()
   const [macros, setMacros] = useState<any>()
-  const [builderView, setBuilderView] = useState(true)
+  const [rawEditor, setRawEditor] = useState<any>(false)
   const [format, setFormat] = useState<SelectableValue<string>>()
 
   useEffect(() => {
@@ -79,6 +79,13 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   }, [format])
 
   useEffect(() => {
+    // set the editor on the query
+    onChange({...query, rawEditor: rawEditor})
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rawEditor])
+
+  useEffect(() => {
     // get the format off the query on load
     if (query.format) {
       setFormat({value: query.format, label: query.format})
@@ -89,9 +96,12 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
       setFormat(QUERY_FORMAT_OPTIONS[1])
     }
 
-    if (query.queryText) {
-      console.log('in here')
-      setBuilderView(false)
+    // check if a query has previously been sent from a
+    // specific editor and default to that
+    if (query.rawEditor) {
+      setRawEditor(query.rawEditor)
+    } else {
+      setRawEditor(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -108,9 +118,9 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
             setIsExpanded(false)
           }}
         >
-          {builderView
-            ? 'By switching to the raw sql editor if you click to come back to the builder view you will need to refill your query.'
-            : 'By switching to the builder view you will not bring your current raw query over to the builder editor, you will have to fill it out again.'}
+          {rawEditor
+            ? 'By switching to the builder view you will not bring your current raw query over to the builder editor, you will have to fill it out again.'
+            : 'By switching to the raw sql editor if you click to come back to the builder view you will need to refill your query.'}
           <Modal.ButtonRow>
             <Button fill="solid" size="md" variant="secondary" onClick={() => setIsExpanded(!isExpanded)}>
               Back
@@ -121,7 +131,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
               variant="destructive"
               onClick={() => {
                 setIsExpanded(!isExpanded)
-                setBuilderView(!builderView)
+                setRawEditor(!rawEditor)
               }}
             >
               Switch
@@ -129,9 +139,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
           </Modal.ButtonRow>
         </Modal>
       )}
-      {builderView ? (
-        <BuilderView query={props.query} datasource={datasource} onChange={onChange} />
-      ) : (
+      {rawEditor ? (
         <QueryEditorRaw
           query={query}
           onChange={onChange}
@@ -140,6 +148,8 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
             completionProvider,
           }}
         />
+      ) : (
+        <BuilderView query={props.query} datasource={datasource} onChange={onChange} />
       )}
       <div style={{width: '100%'}}>
         <InlineFieldRow style={{flexFlow: 'row', alignItems: 'center'}}>
@@ -153,7 +163,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
             />
           </SegmentSection>
           <Button style={{marginLeft: '5px'}} fill="outline" size="md" onClick={() => setIsExpanded(!isExpanded)}>
-            {builderView ? 'Edit SQL' : 'Builder View'}
+            {rawEditor ? 'Builder View' : 'Edit SQL'}
           </Button>
         </InlineFieldRow>
       </div>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -17,6 +17,8 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [builderView, setView] = useState(false)
   const [format, setFormat] = useState<SelectableValue<string>>()
 
+  console.log('query', query)
+
   useEffect(() => {
     ;(async () => {
       const res = await datasource.getSQLInfo()
@@ -77,6 +79,8 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   // useEffect(() => {
   //   setFormat(QUERY_FORMAT_OPTIONS[1])
   // }, [])
+
+  console.log('query', query)
 
   return (
     <>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -14,7 +14,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [isExpanded, setIsExpanded] = useState(false)
   const [sqlInfo, setSqlInfo] = useState<any>()
   const [macros, setMacros] = useState<any>()
-  const [builderView, setView] = useState(true)
+  const [builderView, setView] = useState(false)
   const [format, setFormat] = useState<SelectableValue<string>>()
 
   useEffect(() => {
@@ -74,9 +74,9 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [format])
 
-  useEffect(() => {
-    setFormat(QUERY_FORMAT_OPTIONS[1])
-  }, [])
+  // useEffect(() => {
+  //   setFormat(QUERY_FORMAT_OPTIONS[1])
+  // }, [])
 
   return (
     <>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -14,10 +14,8 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [isExpanded, setIsExpanded] = useState(false)
   const [sqlInfo, setSqlInfo] = useState<any>()
   const [macros, setMacros] = useState<any>()
-  const [builderView, setView] = useState(false)
+  const [builderView, setBuilderView] = useState(true)
   const [format, setFormat] = useState<SelectableValue<string>>()
-
-  console.log('query', query)
 
   useEffect(() => {
     ;(async () => {
@@ -72,15 +70,31 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   )
 
   useEffect(() => {
-    onChange({...query, format: format?.value})
+    // sets the format on the query on dropdown change
+    if (format) {
+      onChange({...query, format: format?.value})
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [format])
 
-  // useEffect(() => {
-  //   setFormat(QUERY_FORMAT_OPTIONS[1])
-  // }, [])
+  useEffect(() => {
+    // get the format off the query on load
+    if (query.format) {
+      setFormat({value: query.format, label: query.format})
+    }
+    // set the default to table
+    // if the user hadn't previously submitted a query with a format
+    if (!query.format) {
+      setFormat(QUERY_FORMAT_OPTIONS[1])
+    }
 
-  console.log('query', query)
+    if (query.queryText) {
+      console.log('in here')
+      setBuilderView(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>
@@ -107,7 +121,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
               variant="destructive"
               onClick={() => {
                 setIsExpanded(!isExpanded)
-                setView(!builderView)
+                setBuilderView(!builderView)
               }}
             >
               Switch

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -167,7 +167,7 @@ export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider
         getStandardSQLCompletionProvider(monaco, {
           ...language,
           builtinFunctions: sqlInfo?.builtinFunctions,
-          keywords: sqlInfo.keywords,
+          keywords: sqlInfo?.keywords,
         })),
       triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
       tables: {

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -166,7 +166,7 @@ export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider
       ...(language &&
         getStandardSQLCompletionProvider(monaco, {
           ...language,
-          builtinFunctions: sqlInfo.builtinFunctions,
+          builtinFunctions: sqlInfo?.builtinFunctions,
           keywords: sqlInfo.keywords,
         })),
       triggerCharacters: ['.', ' ', '$', ',', '(', "'"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import {formatSQL} from './components/sqlFormatter'
 export interface SQLQuery extends DataQuery {
   queryText?: string
   format?: string
+  rawEditor?: boolean
 }
 
 export const DEFAULT_QUERY: Partial<SQLQuery> = {}


### PR DESCRIPTION
- take the format off the query if there is one - this is especially useful for page reloads or in the case of alerting

- on load check if there is a query text if so default to the raw query editor 