### PR TITLE
chore: Fill out more of the metadata about our plugin.

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -13,7 +13,7 @@
       "name": "InfluxData"
       "url": "https://influxdata.com",
     },
-    "keywords": ["datasource"],
+    "keywords": ["datasource", "apache", "arrow", "flight", "flightsql"],
     "logos": {
       "small": "img/arrow-logo.png",
       "large": "img/arrow-logo.png"

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -10,8 +10,8 @@
   "info": {
     "description": "Query databases that support Flight SQL transport.",
     "author": {
-      "name": "InfluxData"
-      "url": "https://influxdata.com",
+      "name": "InfluxData",
+      "url": "https://influxdata.com"
     },
     "keywords": ["datasource", "apache", "arrow", "flight", "flightsql"],
     "logos": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -8,16 +8,22 @@
   "alerting": true,
   "executable": "gpx_flightsql_datasource",
   "info": {
-    "description": "",
+    "description": "Query databases that support Flight SQL transport.",
     "author": {
-      "name": "Grafana"
+      "name": "InfluxData"
+      "url": "https://influxdata.com",
     },
     "keywords": ["datasource"],
     "logos": {
       "small": "img/arrow-logo.png",
       "large": "img/arrow-logo.png"
     },
-    "links": [],
+    "links": [
+      {
+        "name": "Website",
+        "url": "https://github.com/influxdata/grafana-flightsql-datasource"
+      }
+    ],
     "screenshots": [],
     "version": "%VERSION%",
     "updated": "%TODAY%"


### PR DESCRIPTION
Sets the author, description and website of the plugin source code. This is all visible when you're about to install the plugin in the plugins listing.