### PR TITLE
fix: check against version we are using

### DIFF
--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        run: npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/ui,@grafana/runtime
+        run: npx @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data@9.3.2,@grafana/ui@9.3.2,@grafana/runtime@9.3.2


### PR DESCRIPTION
as a precursor to https://github.com/influxdata/grafana-flightsql-datasource/issues/52 which will make us check against 9.x versions lets stop running a check against all versions of grafana it's an unreliable check that mainly just points out type changes.