### PR TITLE
feat/populate builder view and other state fixes

### DIFF
--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -88,7 +88,6 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   })
 
   useEffect(() => {
-    // do i need from raw sql anymore or can it be dictated by the presence of query.table instead
     if (!fromRawSql) {
       if (query.table) {
         setTable({value: query.table, label: query.table})

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -109,6 +109,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
         setLimit(query.limit)
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   return (
     <>

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -112,7 +112,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   }, [])
   return (
     <>
-      <InlineField labelWidth={20} label="Show Raw SQL">
+      <InlineField labelWidth={20} label="Show Query Preview">
         <InlineSwitch
           label=""
           value={rawSql}
@@ -124,7 +124,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
         />
       </InlineField>
       {rawSql && (
-        <SegmentSection label="Raw Query">
+        <SegmentSection label="query preview">
           <SegmentInput disabled style={{minWidth: '50px'}} value={query.queryText} onChange={() => {}} />
         </SegmentSection>
       )}

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import {css} from '@emotion/css'
 
-import {Select, SegmentSection, InlineLabel, Input} from '@grafana/ui'
+import {Select, SegmentSection, InlineLabel, Input, InlineField, InlineSwitch, SegmentInput} from '@grafana/ui'
 import {SelectableValue} from '@grafana/data'
 import {
   GetTables,
@@ -30,6 +30,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   const [columns, setColumns] = useState()
   const [table, setTable] = useState<SelectableValue<string>>()
   const [column, setColumn] = useState<SelectableValue<string>>()
+  const [rawSql, showRawSql] = useState(false)
 
   const {loadingTable, tables, errorTable} = GetTables(datasource)
 
@@ -111,7 +112,23 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   }, [])
   return (
     <>
-      <div className={selectClass}>
+      <InlineField labelWidth={20} label="Show Raw SQL">
+        <InlineSwitch
+          label=""
+          value={rawSql}
+          onChange={() => {
+            showRawSql(!rawSql)
+          }}
+          showLabel={false}
+          disabled={false}
+        />
+      </InlineField>
+      {rawSql && (
+        <SegmentSection label="Raw Query">
+          <SegmentInput disabled style={{minWidth: '50px'}} value={query.queryText} onChange={() => {}} />
+        </SegmentSection>
+      )}
+      <div className={selectClass} style={{paddingTop: '5px'}}>
         <SegmentSection label="FROM" fill={true}>
           <Select
             options={tables}

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -20,7 +20,7 @@ import {
 import {SelectColumn} from './SelectColumn'
 import {WhereExp} from './WhereExp'
 
-export function BuilderView({query, datasource, onChange}: any) {
+export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   const [columnValues, setColumnValues] = useState([{value: ''}])
   const [whereValues, setWhereValues] = useState([{value: ''}])
   const [groupBy, setGroupBy] = useState('')
@@ -49,12 +49,22 @@ export function BuilderView({query, datasource, onChange}: any) {
   }, [table, datasource])
 
   useEffect(() => {
-    if (table && column) {
+    // in the case where its loaded on refresh there is no column
+    if (table && (column || columnValues)) {
       const selectColumns = formatColumns(columnValues)
       const casedTable = checkCasing(table.value || '')
       const whereExps = formatWheres(whereValues)
       const queryText = buildQueryString(selectColumns, casedTable, whereExps, orderBy, groupBy, limit)
-      onChange({...query, queryText: queryText})
+      onChange({
+        ...query,
+        queryText: queryText,
+        table: casedTable,
+        columns: columnValues,
+        wheres: whereValues,
+        orderBy: orderBy,
+        groupBy: groupBy,
+        limit: limit,
+      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table, columnValues, groupBy, whereValues, orderBy, limit, column])
@@ -73,13 +83,32 @@ export function BuilderView({query, datasource, onChange}: any) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [where])
 
-  useEffect(() => {
-    setColumnValues([{value: ''}])
-  }, [table])
-
   const selectClass = css({
     minWidth: '160px',
   })
+
+  useEffect(() => {
+    if (!fromRawSql) {
+      if (query.table) {
+        setTable({value: query.table, label: query.table})
+      }
+      if (query.columns) {
+        setColumnValues(query.columns)
+      }
+      if (query.wheres) {
+        setWhereValues(query.wheres)
+      }
+      if (query.groupBy) {
+        setGroupBy(query.groupBy)
+      }
+      if (query.orderBy) {
+        setOrderBy(query.orderBy)
+      }
+      if (query.limit) {
+        setLimit(query.limit)
+      }
+    }
+  }, [])
   return (
     <>
       <div className={selectClass}>
@@ -93,7 +122,7 @@ export function BuilderView({query, datasource, onChange}: any) {
             allowCustomValue={true}
             autoFocus={true}
             formatCreateLabel={formatCreateLabel}
-            width={15}
+            width={20}
             placeholder="table"
           />
         </SegmentSection>
@@ -180,7 +209,7 @@ export function BuilderView({query, datasource, onChange}: any) {
               setGroupBy(e.currentTarget.value)
             }}
             value={groupBy}
-            width={15}
+            width={20}
             placeholder="(optional)"
           />
         </SegmentSection>
@@ -200,7 +229,7 @@ export function BuilderView({query, datasource, onChange}: any) {
               setOrderBy(e.currentTarget.value)
             }}
             value={orderBy}
-            width={15}
+            width={20}
             placeholder="(optional)"
           />
         </SegmentSection>
@@ -220,7 +249,7 @@ export function BuilderView({query, datasource, onChange}: any) {
               setLimit(e.currentTarget.value)
             }}
             value={limit}
-            width={15}
+            width={20}
             placeholder="(optional)"
           />
         </SegmentSection>

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import {css} from '@emotion/css'
 
-import {Select, SegmentSection, InlineLabel, Input, InlineField, InlineSwitch, SegmentInput} from '@grafana/ui'
+import {Select, SegmentSection, InlineLabel, Input} from '@grafana/ui'
 import {SelectableValue} from '@grafana/data'
 import {
   GetTables,
@@ -30,7 +30,6 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   const [columns, setColumns] = useState()
   const [table, setTable] = useState<SelectableValue<string>>()
   const [column, setColumn] = useState<SelectableValue<string>>()
-  const [rawSql, showRawSql] = useState(false)
 
   const {loadingTable, tables, errorTable} = GetTables(datasource)
 
@@ -89,6 +88,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   })
 
   useEffect(() => {
+    // do i need from raw sql anymore or can it be dictated by the presence of query.table instead
     if (!fromRawSql) {
       if (query.table) {
         setTable({value: query.table, label: query.table})
@@ -113,22 +113,6 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   }, [])
   return (
     <>
-      <InlineField labelWidth={20} label="Show Query Preview">
-        <InlineSwitch
-          label=""
-          value={rawSql}
-          onChange={() => {
-            showRawSql(!rawSql)
-          }}
-          showLabel={false}
-          disabled={false}
-        />
-      </InlineField>
-      {rawSql && (
-        <SegmentSection label="query preview">
-          <SegmentInput disabled style={{minWidth: '50px'}} value={query.queryText} onChange={() => {}} />
-        </SegmentSection>
-      )}
       <div className={selectClass} style={{paddingTop: '5px'}}>
         <SegmentSection label="FROM" fill={true}>
           <Select

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -30,16 +30,6 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
 
   useEffect(() => {
     const {onOptionsChange, options} = props
-    const jsonData = {
-      ...options.jsonData,
-      secure: true,
-    }
-    onOptionsChange({...options, jsonData})
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(() => {
-    const {onOptionsChange, options} = props
     const mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
     const jsonData = {
       ...options.jsonData,

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -18,8 +18,11 @@ import {
 export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQLDataSourceOptions>) {
   const {options, onOptionsChange} = props
   const {jsonData} = options
-  const [selectedAuthType, setAuthType] = useState<SelectableValue<string>>(authTypeOptions[2])
-  const [metaDataArr, setMetaData] = useState([{key: '', value: ''}])
+  const [selectedAuthType, setAuthType] = useState<SelectableValue<string>>(
+    {value: jsonData.selectedAuthType, label: jsonData.selectedAuthType} || authTypeOptions[2]
+  )
+  const existingMetastate = jsonData?.metadata?.map((m: any) => ({key: Object.keys(m)[0], value: Object.values(m)[0]}))
+  const [metaDataArr, setMetaData] = useState(existingMetastate || [{key: '', value: ''}])
   useEffect(() => {
     onAuthTypeChange(selectedAuthType, options, onOptionsChange)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -29,7 +32,6 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
     const {onOptionsChange, options} = props
     const jsonData = {
       ...options.jsonData,
-      selectedAuthType: 'token',
       secure: true,
     }
     onOptionsChange({...options, jsonData})
@@ -38,7 +40,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
 
   useEffect(() => {
     const {onOptionsChange, options} = props
-    const mapData = metaDataArr.map((m) => ({[m.key]: m.value}))
+    const mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
     const jsonData = {
       ...options.jsonData,
       metadata: mapData,
@@ -64,10 +66,8 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
           <Select
             options={authTypeOptions}
             onChange={setAuthType}
-            value={jsonData.selectedAuthType || ''}
+            value={selectedAuthType || ''}
             allowCustomValue={true}
-            autoFocus={true}
-            // formatCreateLabel={}
             width={40}
             placeholder="token"
           />

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -180,7 +180,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
       {!rawEditor && (
         <div style={{marginTop: '5px'}}>
           <SegmentSection label="Query Preview">
-            <div style={{fontFamily: 'monospace'}}>
+            <div style={{fontFamily: 'monospace', minWidth: '200px'}}>
               <SegmentInput disabled value={query.queryText || ''} onChange={() => {}} />
             </div>
           </SegmentSection>{' '}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -136,6 +136,9 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
                 showWarningModal(!warningModal)
                 setRawEditor(!rawEditor)
                 setFromSql(rawEditor)
+                if (rawEditor) {
+                  query.queryText = ''
+                }
               }}
             >
               Switch

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useMemo, useCallback, useEffect} from 'react'
-import {Button, Modal, SegmentSection, Select, InlineFieldRow} from '@grafana/ui'
+import {Button, Modal, SegmentSection, Select, InlineFieldRow, SegmentInput} from '@grafana/ui'
 import {QueryEditorProps, SelectableValue} from '@grafana/data'
 import {MacroType} from '@grafana/experimental'
 import {FlightSQLDataSource} from '../datasource'
@@ -177,6 +177,15 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
           </Button>
         </InlineFieldRow>
       </div>
+      {!rawEditor && (
+        <div style={{marginTop: '5px'}}>
+          <SegmentSection label="Query Preview">
+            <div style={{fontFamily: 'monospace'}}>
+              <SegmentInput disabled value={query.queryText || ''} onChange={() => {}} />
+            </div>
+          </SegmentSection>{' '}
+        </div>
+      )}
       {helpModal && <QueryHelp />}
     </>
   )

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -18,6 +18,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
   const [macros, setMacros] = useState<any>()
   const [rawEditor, setRawEditor] = useState<any>(false)
   const [format, setFormat] = useState<SelectableValue<string>>()
+  const [fromRawSql, setFromSql] = useState(false)
 
   useEffect(() => {
     ;(async () => {
@@ -134,6 +135,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
               onClick={() => {
                 showWarningModal(!warningModal)
                 setRawEditor(!rawEditor)
+                setFromSql(rawEditor)
               }}
             >
               Switch
@@ -151,7 +153,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
           }}
         />
       ) : (
-        <BuilderView query={props.query} datasource={datasource} onChange={onChange} />
+        <BuilderView query={props.query} datasource={datasource} onChange={onChange} fromRawSql={fromRawSql} />
       )}
       <div style={{width: '100%'}}>
         <InlineFieldRow style={{flexFlow: 'row', alignItems: 'center'}}>

--- a/src/components/SelectColumn.tsx
+++ b/src/components/SelectColumn.tsx
@@ -12,7 +12,7 @@ export const SelectColumn = ({columns, index, setColumn, columnValues, formatCre
     value={columnValues[index].value}
     allowCustomValue={true}
     formatCreateLabel={formatCreateLabel}
-    width={15}
+    width={20}
     placeholder="column"
   />
 )

--- a/src/components/WhereExp.tsx
+++ b/src/components/WhereExp.tsx
@@ -15,7 +15,7 @@ export const WhereExp = ({index, setWhere, whereValues}: any) => (
       setWhere({value: e.currentTarget.value, index: index})
     }}
     value={whereValues[index].value}
-    width={15}
+    width={20}
     placeholder="value = value"
   />
 )

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -122,7 +122,7 @@ export const onHostChange = (event: any, options: any, onOptionsChange: any) => 
 export const onTokenChange = (event: any, options: any, onOptionsChange: any) => {
   const jsonData = {
     ...options.jsonData,
-    token: event.target.value,
+    token: event?.target?.value || '',
   }
   onOptionsChange({...options, jsonData})
 }
@@ -202,11 +202,6 @@ export const onKeyChange = (
 ) => {
   let newMetaValues = [...metaDataArr]
   newMetaValues[index]['key'] = event.target.value
-  const jsonData = {
-    ...options.jsonData,
-    metadata: newMetaValues,
-  }
-  onOptionsChange({...options, jsonData})
   setMetaData(newMetaValues)
 }
 
@@ -220,10 +215,5 @@ export const onValueChange = (
 ) => {
   let newMetaValues = [...metaDataArr]
   newMetaValues[index]['value'] = event.target.value
-  const jsonData = {
-    ...options.jsonData,
-    metadata: newMetaValues,
-  }
-  onOptionsChange({...options, jsonData})
   setMetaData(newMetaValues)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ export interface SQLQuery extends DataQuery {
   queryText?: string
   format?: string
   rawEditor?: boolean
+  table?: string
+  columns?: string[]
+  wheres?: string[]
+  orderBy?: string
+  groupBy?: string
+  limit?: string
 }
 
 export const DEFAULT_QUERY: Partial<SQLQuery> = {}


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/71
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/74

- [x] if you used the builder view and refresh keep the values populated - this is important in alerting and dashboards to persist the visible state of the builder view
- [x] add a show query toggle so users can see the query while they are in the builder view
- [x] if a user switches from rawSql to builder view the state should be cleared
- [x] if a user switches from builder to raw sql the query state should be kept in the raw sql view
- [x] fixes the meta data so on refresh the state is there if you have previously entered it
- [x] fixes default token state
- [x] widen width of builder view entries

<img width="813" alt="Screen Shot 2023-01-27 at 1 39 00 PM" src="https://user-images.githubusercontent.com/38860767/215205636-34e56d7a-f8b0-4666-b45a-ee0045deb586.png">
