### PR TITLE
feat(query): Execute queries concurrently

### DIFF
--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -32,7 +32,7 @@ type recordReader interface {
 // [arrow.Record]s.
 //
 // The backend.DataResponse contains a single [data.Frame].
-func newQueryDataResponse(reader recordReader, query *sqlutil.Query) backend.DataResponse {
+func newQueryDataResponse(reader recordReader, query sqlutil.Query) backend.DataResponse {
 	var resp backend.DataResponse
 	frame, err := frameForRecords(reader)
 	if err != nil {
@@ -180,7 +180,7 @@ func newFrame(schema *arrow.Schema) *data.Frame {
 func copyData(field *data.Field, col arrow.Array) error {
 	defer func() {
 		if r := recover(); r != nil {
-			logErrorf("Panic: %v %v", r, string(debug.Stack()))
+			logErrorf("Panic: %s %s", r, string(debug.Stack()))
 		}
 	}()
 

--- a/pkg/flightsql/arrow_test.go
+++ b/pkg/flightsql/arrow_test.go
@@ -45,7 +45,7 @@ func TestNewQueryDataResponse(t *testing.T) {
 	reader, err := array.NewRecordReader(schema, records)
 	require.NoError(t, err)
 
-	query := &sqlutil.Query{Format: sqlutil.FormatOptionTable}
+	query := sqlutil.Query{Format: sqlutil.FormatOptionTable}
 	resp := newQueryDataResponse(errReader{RecordReader: reader}, query)
 	require.NoError(t, resp.Error)
 	require.Len(t, resp.Frames, 1)
@@ -95,7 +95,7 @@ func TestNewQueryDataResponse_Error(t *testing.T) {
 		RecordReader: reader,
 		err:          fmt.Errorf("explosion!"),
 	}
-	query := &sqlutil.Query{Format: sqlutil.FormatOptionTable}
+	query := sqlutil.Query{Format: sqlutil.FormatOptionTable}
 	resp := newQueryDataResponse(wrappedReader, query)
 	require.Error(t, resp.Error)
 	require.Equal(t, fmt.Errorf("explosion!"), resp.Error)
@@ -136,7 +136,7 @@ func TestNewQueryDataResponse_WideTable(t *testing.T) {
 	reader, err := array.NewRecordReader(schema, records)
 	require.NoError(t, err)
 
-	resp := newQueryDataResponse(errReader{RecordReader: reader}, &sqlutil.Query{})
+	resp := newQueryDataResponse(errReader{RecordReader: reader}, sqlutil.Query{})
 	require.NoError(t, resp.Error)
 	require.Len(t, resp.Frames, 1)
 	require.Equal(t, 3, resp.Frames[0].Rows())

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -133,7 +133,7 @@ func (d *FlightSQLDatasource) CallResource(ctx context.Context, req *backend.Cal
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *FlightSQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	query := &sqlutil.Query{
+	query := sqlutil.Query{
 		RawSQL: "select 1",
 		Format: sqlutil.FormatOptionTable,
 	}
@@ -156,7 +156,7 @@ func recoverer(next http.Handler) http.Handler {
 				if rec == http.ErrAbortHandler {
 					panic(rec)
 				}
-				logErrorf("Panic: %v %v", r, string(debug.Stack()))
+				logErrorf("Panic: %s %s", rec, string(debug.Stack()))
 				w.WriteHeader(http.StatusInternalServerError)
 			}
 		}()


### PR DESCRIPTION
Execute queries in a `backend.QueryDataRequest` concurrently.