### PR TITLE
feat: add db schema as a prefix to table query in builder view

### DIFF
--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -16,6 +16,7 @@ import {
   formatColumns,
   formatWheres,
   formatCreateLabel,
+  prefixDB,
 } from './utils'
 import {SelectColumn} from './SelectColumn'
 import {WhereExp} from './WhereExp'
@@ -53,8 +54,9 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
     if (table && (column || columnValues)) {
       const selectColumns = formatColumns(columnValues)
       const casedTable = checkCasing(table.value || '')
+      const prefixDBSchema = prefixDB(casedTable, table?.dbSchema)
       const whereExps = formatWheres(whereValues)
-      const queryText = buildQueryString(selectColumns, casedTable, whereExps, orderBy, groupBy, limit)
+      const queryText = buildQueryString(selectColumns, prefixDBSchema, whereExps, orderBy, groupBy, limit)
       onChange({
         ...query,
         queryText: queryText,

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -12,10 +12,22 @@ type AsyncTablesState = {
 export const GetTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
   const result = useAsync(async () => {
     const res = await datasource.getTables()
-    return res.frames[0].data.values[2].map((t: string) => ({
+
+    const dbSchemaArr = res.frames[0].data.values[1].map((t: string) => ({
+      dbSchema: t,
+    }))
+
+    const tableArr = res.frames[0].data.values[2].map((t: string) => ({
       label: t,
       value: t,
     }))
+
+    const mergedArr = dbSchemaArr.map((obj: any, index: string | number) => ({
+      ...obj,
+      ...tableArr[index],
+    }))
+
+    return mergedArr
   }, [datasource])
 
   return {
@@ -60,6 +72,14 @@ export const checkCasing = (str: string) => {
     str = `"${str}"`
   }
 
+  return str
+}
+
+export const prefixDB = (table: string, dbSchema: string) => {
+  let str = table
+  if (dbSchema) {
+    str = `${dbSchema}.${table}`
+  }
   return str
 }
 


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/82

for the use case where a table is shown which is not the default db schema ie iox as in the case with _tasks system.queries table now prefix the query on the builder view with the db schema

this shows in the query text but not in the dropdown as it would make the dropdown hard to read as they would have lots beginning with the same thing


<img width="659" alt="Screen Shot 2023-02-03 at 3 40 47 PM" src="https://user-images.githubusercontent.com/38860767/216706984-8ab59e50-b000-448b-b4d6-c1f100958a1f.png">
<img width="585" alt="Screen Shot 2023-02-03 at 3 41 38 PM" src="https://user-images.githubusercontent.com/38860767/216706992-b81951e0-31af-4455-be2d-76f0fbb86562.png">
