### PR TITLE
fix/ multi datasources

### DIFF
--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -45,6 +45,7 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
       }))
       setColumns(columns)
     })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table])
 
   useEffect(() => {

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -67,7 +67,9 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
 
       setTables(mergedArr)
     })()
-  }, [datasource])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     // in the case where its loaded on refresh there is no column
@@ -110,28 +112,35 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
   })
 
   useEffect(() => {
-    if (!fromRawSql) {
-      if (query.table) {
-        setTable({value: query.table, label: query.table})
+    if (!fromRawSql && tables) {
+      const tableExists = tables?.find((t: any) => t.label === query.table)
+      if (tableExists) {
+        if (query.table) {
+          setTable({value: query.table, label: query.table})
+        }
+        if (query.columns) {
+          setColumnValues(query.columns)
+        }
+        if (query.wheres) {
+          setWhereValues(query.wheres)
+        }
+        if (query.groupBy) {
+          setGroupBy(query.groupBy)
+        }
+        if (query.orderBy) {
+          setOrderBy(query.orderBy)
+        }
+        if (query.limit) {
+          setLimit(query.limit)
+        }
       }
-      if (query.columns) {
-        setColumnValues(query.columns)
-      }
-      if (query.wheres) {
-        setWhereValues(query.wheres)
-      }
-      if (query.groupBy) {
-        setGroupBy(query.groupBy)
-      }
-      if (query.orderBy) {
-        setOrderBy(query.orderBy)
-      }
-      if (query.limit) {
-        setLimit(query.limit)
+      if (!tableExists) {
+        console.log('query', query)
+        query.queryText = ''
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [tables])
   return (
     <>
       <div className={selectClass} style={{paddingTop: '5px'}}>

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,41 +1,4 @@
-import {useAsync} from 'react-use'
-import {FlightSQLDataSource} from '../datasource'
-import {SelectableValue} from '@grafana/data'
 import {LanguageCompletionProvider, getStandardSQLCompletionProvider} from '@grafana/experimental'
-
-type AsyncTablesState = {
-  loadingTable: boolean
-  tables: Array<SelectableValue<string>>
-  errorTable: Error | undefined
-}
-
-export const GetTables = (datasource: FlightSQLDataSource): AsyncTablesState => {
-  const result = useAsync(async () => {
-    const res = await datasource.getTables()
-
-    const dbSchemaArr = res.frames[0].data.values[1].map((t: string) => ({
-      dbSchema: t,
-    }))
-
-    const tableArr = res.frames[0].data.values[2].map((t: string) => ({
-      label: t,
-      value: t,
-    }))
-
-    const mergedArr = dbSchemaArr.map((obj: any, index: string | number) => ({
-      ...obj,
-      ...tableArr[index],
-    }))
-
-    return mergedArr
-  }, [datasource])
-
-  return {
-    loadingTable: result.loading,
-    tables: result.value ?? [],
-    errorTable: result.error,
-  }
-}
 
 export const buildQueryString = (
   columns: string,


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/89

- found a workaround so it gets tables on load and doesn't get columns when the datasource changes only when the selected table changes

- by doing this we can fill out the query when the tables response returns on load and check that the query table exists within the list otherwise reset the state

