### PR TITLE
feat(client): Extract stream headers for query DoGet.

### DIFF
--- a/pkg/flightsql/arrow.go
+++ b/pkg/flightsql/arrow.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"google.golang.org/grpc/metadata"
 )
 
 // TODO(brett): Make this configurable. This is an arbitrary value right
@@ -32,7 +33,7 @@ type recordReader interface {
 // [arrow.Record]s.
 //
 // The backend.DataResponse contains a single [data.Frame].
-func newQueryDataResponse(reader recordReader, query sqlutil.Query) backend.DataResponse {
+func newQueryDataResponse(reader recordReader, query sqlutil.Query, headers metadata.MD) backend.DataResponse {
 	var resp backend.DataResponse
 	frame, err := frameForRecords(reader)
 	if err != nil {
@@ -43,6 +44,9 @@ func newQueryDataResponse(reader recordReader, query sqlutil.Query) backend.Data
 		return resp
 	}
 
+	frame.Meta.Custom = map[string]any{
+		"headers": headers,
+	}
 	frame.Meta.ExecutedQueryString = query.RawSQL
 	frame.Meta.DataTopic = data.DataTopic(query.RawSQL)
 

--- a/pkg/flightsql/client.go
+++ b/pkg/flightsql/client.go
@@ -1,21 +1,31 @@
 package flightsql
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
+	"sync"
 
+	"github.com/apache/arrow/go/v10/arrow/flight"
 	"github.com/apache/arrow/go/v10/arrow/flight/flightsql"
+	"github.com/apache/arrow/go/v10/arrow/ipc"
+	"github.com/apache/arrow/go/v10/arrow/memory"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
-func newFlightSQLClient(cfg config) (*flightsql.Client, error) {
+func newFlightSQLClient(cfg config) (*client, error) {
 	dialOptions, err := grpcDialOptions(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("grpc dial options: %s", err)
 	}
-	return flightsql.NewClient(cfg.Addr, nil, nil, dialOptions...)
+	fsqlc, err := flightsql.NewClient(cfg.Addr, nil, nil, dialOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return &client{fsqlc}, nil
 }
 
 func grpcDialOptions(cfg config) ([]grpc.DialOption, error) {
@@ -33,4 +43,79 @@ func grpcDialOptions(cfg config) ([]grpc.DialOption, error) {
 	}
 
 	return opts, nil
+}
+
+// client wraps a [flightsql.Client] client to extend its behavior.
+//
+// The API provided by flightsql.Client provides no access to gRPC headers for
+// streaming operations such as DoGet. The methods implemented on this type aim
+// to provide access to that information.
+type client struct {
+	*flightsql.Client
+}
+
+// FlightClient returns the underlying [flight.Client].
+func (c *client) FlightClient() flight.Client {
+	return c.Client.Client
+}
+
+// DoGetWithHeaderExtraction performs a normal DoGet, but wraps the stream in a
+// mechanism that extracts headers when they become available. At least one
+// record should be read from the *flightReader before the headers are
+// available.
+func (c *client) DoGetWithHeaderExtraction(ctx context.Context, in *flight.Ticket, opts ...grpc.CallOption) (*flightReader, error) {
+	stream, err := c.FlightClient().DoGet(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return newFlightReader(stream, c.Client.Alloc)
+}
+
+// flightReader wraps a [flight.Reader] to expose the headers captured when the
+// first read occurs on the stream.
+type flightReader struct {
+	*flight.Reader
+	extractor *headerExtractor
+}
+
+// newFlightReader returns a [flightReader].
+func newFlightReader(stream flight.FlightService_DoGetClient, alloc memory.Allocator) (*flightReader, error) {
+	extractor := &headerExtractor{stream: stream}
+	reader, err := flight.NewRecordReader(extractor, ipc.WithAllocator(alloc))
+	if err != nil {
+		return nil, err
+	}
+	return &flightReader{
+		Reader:    reader,
+		extractor: extractor,
+	}, nil
+}
+
+// Header returns the extracted headers if they exist.
+func (s *flightReader) Header() (metadata.MD, error) {
+	return s.extractor.Header()
+}
+
+// headerExtractor collects the stream's headers on the first call to
+// [(*headerExtractor).Recv].
+type headerExtractor struct {
+	stream flight.FlightService_DoGetClient
+
+	once   sync.Once
+	header metadata.MD
+	err    error
+}
+
+// Header returns the extracted headers if they exist.
+func (s *headerExtractor) Header() (metadata.MD, error) {
+	return s.header, s.err
+}
+
+// Recv reads from the stream. The first invocation will capture the headers.
+func (s *headerExtractor) Recv() (*flight.FlightData, error) {
+	data, err := s.stream.Recv()
+	s.once.Do(func() {
+		s.header, s.err = s.stream.Header()
+	})
+	return data, err
 }

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -8,7 +8,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/apache/arrow/go/v10/arrow/flight/flightsql"
 	"github.com/go-chi/chi/v5"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -51,7 +50,7 @@ func (cfg config) validate() error {
 
 // FlightSQLDatasource is a Grafana datasource plugin for Flight SQL.
 type FlightSQLDatasource struct {
-	client          *flightsql.Client
+	client          *client
 	resourceHandler backend.CallResourceHandler
 	md              metadata.MD
 }
@@ -86,7 +85,7 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 
 	ctx := context.Background()
 	if len(cfg.Username) > 0 || len(cfg.Password) > 0 {
-		ctx, err = client.Client.AuthenticateBasicToken(ctx, cfg.Username, cfg.Password)
+		ctx, err = client.FlightClient().AuthenticateBasicToken(ctx, cfg.Username, cfg.Password)
 		if err != nil {
 			return nil, fmt.Errorf("flightsql: %s", err)
 		}

--- a/pkg/flightsql/resources.go
+++ b/pkg/flightsql/resources.go
@@ -150,7 +150,7 @@ func (d *FlightSQLDatasource) getColumns(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func newDataResponse(reader *flight.Reader) backend.DataResponse {
+func newDataResponse(reader recordReader) backend.DataResponse {
 	var resp backend.DataResponse
 	frame := newFrame(reader.Schema())
 READER:


### PR DESCRIPTION
The API provided by the Flight SQL client doesn't allow access to gRPC metadata for streaming operations such as `DoGet`.

To work around this problem, I've implemented a small wrapper for the client that implements an additional `DoGetWithHeaderExtraction` method. This method performs a normal `DoGet` (using the underlying Flight RPC client), but returns a custom type that exposes the headers obtained after the first stream read.

The headers are then applied to the outgoing dataframe's metadata, and can be accessed using the Grafana query debugger.

We should consider opening a discussion with the upstream project about improving the Flight SQL client to make header/trailer access possible.