### PR TITLE
chore: Update README to point to latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The plugin requires the user to run Grafana ^9.2.5.
 Download the latest release:
 
 ```sh
-$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.0/influxdata-flightsql-datasource-0.1.1.zip
+$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.0/influxdata-flightsql-datasource-0.1.5.zip
 ```
 
 Unzip the release into your Grafana plugins directory:
 
 ```
-$ unzip influxdata-flightsql-datasource-0.1.1.zip -d grafana-plugins/
+$ unzip influxdata-flightsql-datasource-0.1.5.zip -d grafana-plugins/
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The plugin requires the user to run Grafana ^9.2.5.
 Download the latest release:
 
 ```sh
-$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.0/influxdata-flightsql-datasource-0.1.5.zip
+$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.5/influxdata-flightsql-datasource-0.1.5.zip
 ```
 
 Unzip the release into your Grafana plugins directory:


### PR DESCRIPTION
A tiny update to the readme to point at the latest release.

Are we able to tag releases "latest" automatically, and then point at that tag instead?

I've seen it done, but I don't know what's involved.  I'm happy to take a look if you like?
