### PR TITLE
fix: resolve panic where no metadata was entered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ The plugin requires the user to run Grafana ^9.2.5.
 Download the latest release:
 
 ```sh
-$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.5/influxdata-flightsql-datasource-0.1.5.zip
+$ curl -L https://github.com/influxdata/grafana-flightsql-datasource/releases/download/v0.1.6/influxdata-flightsql-datasource-0.1.6.zip
 ```
 
 Unzip the release into your Grafana plugins directory:
 
 ```
-$ unzip influxdata-flightsql-datasource-0.1.5.zip -d grafana-plugins/
+$ unzip influxdata-flightsql-datasource-0.1.6.zip -d grafana-plugins/
 ```
 
 ### Configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flightsql-datasource",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -41,7 +41,8 @@ func (cfg config) validate() error {
 	noToken := len(cfg.Token) == 0
 	noUserPass := len(cfg.Username) == 0 || len(cfg.Password) == 0
 
-	if noToken && noUserPass {
+	// if not secure don't make users supply a token
+	if noToken && noUserPass && cfg.Secure {
 		return fmt.Errorf("token or username/password are required")
 	}
 

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -100,7 +100,7 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 		}
 		authMD, _ := metadata.FromOutgoingContext(ctx)
 		md = metadata.Join(md, authMD)
-	} 
+	}
 
 	if cfg.Token != "" {
 		md.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.Token))

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -100,7 +100,9 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 		}
 		authMD, _ := metadata.FromOutgoingContext(ctx)
 		md = metadata.Join(md, authMD)
-	} else {
+	} 
+
+	if cfg.Token != "" {
 		md.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.Token))
 	}
 

--- a/pkg/flightsql/query_data.go
+++ b/pkg/flightsql/query_data.go
@@ -109,7 +109,10 @@ func (d *FlightSQLDatasource) query(ctx context.Context, query sqlutil.Query) (r
 		}
 	}()
 
-	ctx = metadata.NewOutgoingContext(ctx, d.md)
+	if d.md.Len() != 0 {
+		ctx = metadata.NewOutgoingContext(ctx, d.md)
+	}
+
 	info, err := d.client.Execute(ctx, query.RawSQL)
 	if err != nil {
 		return backend.ErrDataResponse(backend.StatusInternal, fmt.Sprintf("flightsql: %s", err))

--- a/src/components/BuilderView.test.tsx
+++ b/src/components/BuilderView.test.tsx
@@ -9,6 +9,9 @@ beforeAll(() => {
     if (/Warning.*not wrapped in act/.test(args[0])) {
       return
     }
+    if (/Each child in a list should have a unique "key" prop/.test(args[0])) {
+      return
+    }
     originalError.call(console, ...args)
   }
 })
@@ -20,7 +23,10 @@ afterAll(() => {
 const setup = async (optionOverrides?: object) => {
   const props = {
     query: '',
-    datasource: '',
+    datasource: {
+      getTables: () => {},
+      getColumns: () => {}
+    },
     onChange: () => {},
     fromRawSql: true,
   }

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -52,16 +52,16 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
     ;(async () => {
       const res = await datasource.getTables()
 
-      const dbSchemaArr = res.frames[0].data.values[1].map((t: string) => ({
+      const dbSchemaArr = res?.frames[0].data.values[1].map((t: string) => ({
         dbSchema: t,
       }))
 
-      const tableArr = res.frames[0].data.values[2].map((t: string) => ({
+      const tableArr = res?.frames[0].data.values[2].map((t: string) => ({
         label: t,
         value: t,
       }))
 
-      const mergedArr = dbSchemaArr.map((obj: any, index: string | number) => ({
+      const mergedArr = dbSchemaArr?.map((obj: any, index: string | number) => ({
         ...obj,
         ...tableArr[index],
       }))

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -26,7 +26,9 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
     value: jsonData?.selectedAuthType,
     label: jsonData?.selectedAuthType,
   })
-  const existingMetastate = jsonData?.metadata?.map((m: any) => ({key: Object.keys(m)[0], value: Object.values(m)[0]}))
+  const hasMeta = jsonData?.metadata?.length > 0
+  const existingMetastate =
+    hasMeta && jsonData?.metadata?.map((m: any) => ({key: Object.keys(m)[0], value: Object.values(m)[0]}))
   const [metaDataArr, setMetaData] = useState(existingMetastate || [{key: '', value: ''}])
   useEffect(() => {
     onAuthTypeChange(selectedAuthType, options, onOptionsChange)
@@ -35,7 +37,11 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
 
   useEffect(() => {
     const {onOptionsChange, options} = props
-    const mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
+    let mapData = []
+    if (metaDataArr[0]?.key !== '') {
+      mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
+    }
+
     const jsonData = {
       ...options.jsonData,
       metadata: mapData,
@@ -128,7 +134,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
                 width={40}
                 name="key"
                 type="text"
-                value={metaDataArr[i].key || ''}
+                value={metaDataArr[i]?.key || ''}
                 placeholder="key"
                 onChange={(e) => onKeyChange(e, metaDataArr, i, setMetaData)}
               ></Input>
@@ -139,7 +145,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
                 width={40}
                 name="value"
                 type="text"
-                value={metaDataArr[i].value || ''}
+                value={metaDataArr[i]?.value || ''}
                 placeholder="value"
                 onChange={(e) => onValueChange(e, metaDataArr, i, setMetaData)}
               ></Input>

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -26,9 +26,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
     value: jsonData?.selectedAuthType,
     label: jsonData?.selectedAuthType,
   })
-  const hasMeta = jsonData?.metadata?.length > 0
-  const existingMetastate =
-    hasMeta && jsonData?.metadata?.map((m: any) => ({key: Object.keys(m)[0], value: Object.values(m)[0]}))
+  const existingMetastate = jsonData?.metadata?.length && jsonData?.metadata?.map((m: any) => ({key: Object.keys(m)[0], value: Object.values(m)[0]}))
   const [metaDataArr, setMetaData] = useState(existingMetastate || [{key: '', value: ''}])
   useEffect(() => {
     onAuthTypeChange(selectedAuthType, options, onOptionsChange)
@@ -37,17 +35,16 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
 
   useEffect(() => {
     const {onOptionsChange, options} = props
-    let mapData = []
+    let mapData
+    let jsonData
     if (metaDataArr[0]?.key !== '') {
       mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
+        jsonData = {
+        ...options.jsonData,
+        metadata: mapData,
+      }
+      onOptionsChange({...options, jsonData})
     }
-
-    const jsonData = {
-      ...options.jsonData,
-      metadata: mapData,
-      secure: true,
-    }
-    onOptionsChange({...options, jsonData})
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [metaDataArr])
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -45,7 +45,7 @@ export function QueryEditor(props: QueryEditorProps<FlightSQLDataSource, SQLQuer
 
   const getTables = useCallback(async () => {
     const res = await datasource.getTables()
-    return res.frames[0].data.values[2].map((t: string) => ({
+    return res?.frames[0].data.values[2].map((t: string) => ({
       name: checkCasing(t),
     }))
   }, [datasource])


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/111 
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/112
- [x] bumps version for publishing
- [x] only ask for password/token if secure mode is selected
- [x] only append metadata if it exists
- [x] only append bearer metadata if a token is provided
- [x] in the ui only send metadata to the backend if the key/value is not the empty string placeholder
- [x] we changed our default branch to main but didn't update our ci workflow - hence no tests were running against prs