### PR TITLE
fix: get tables for sqllite client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flightsql-datasource",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/flightsql/flightsql.go
+++ b/pkg/flightsql/flightsql.go
@@ -88,7 +88,9 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 			if _, ok := md[k]; ok {
 				return nil, fmt.Errorf("metadata: duplicate key: %s", k)
 			}
-			md.Set(k, v)
+			if k != "" {
+				md.Set(k, v)
+			}
 		}
 	}
 

--- a/pkg/flightsql/resources.go
+++ b/pkg/flightsql/resources.go
@@ -71,9 +71,16 @@ func (d *FlightSQLDatasource) getTables(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, d.md)
-	info, err := d.client.GetTables(ctx, &flightsql.GetTablesOpts{
-		TableTypes: []string{"BASE TABLE"},
-	})
+	bucketMetaData := d.md.Get("bucket-name")
+
+	opts := &flightsql.GetTablesOpts{}
+
+	if len(bucketMetaData) > 0 {
+		opts = &flightsql.GetTablesOpts{
+			TableTypes: []string{"BASE TABLE"},
+		}
+	}
+	info, err := d.client.GetTables(ctx, opts)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -34,17 +34,13 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps<FlightSQL
   }, [selectedAuthType])
 
   useEffect(() => {
-    const {onOptionsChange, options} = props
-    let mapData
-    let jsonData
-    if (metaDataArr[0]?.key !== '') {
-      mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
-        jsonData = {
+    const {onOptionsChange, options} = props  
+      const mapData = metaDataArr?.map((m: any) => ({[m.key]: m.value}))
+        const jsonData = {
         ...options.jsonData,
         metadata: mapData,
       }
       onOptionsChange({...options, jsonData})
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [metaDataArr])
 

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -131,11 +131,27 @@ export const onPasswordChange = (event: any, options: any, onOptionsChange: any)
 }
 
 export const onAuthTypeChange = (selectedAuthType: any, options: any, onOptionsChange: any) => {
-  const jsonData = {
-    ...options.jsonData,
-    selectedAuthType: selectedAuthType?.label,
-  }
-  onOptionsChange({...options, jsonData})
+  const notTokenType =  selectedAuthType?.label !== "token"
+  const notPassType = selectedAuthType?.label !== "username/password"
+
+  onOptionsChange({
+    ...options,
+    jsonData: {
+      ...options.jsonData,
+      selectedAuthType: selectedAuthType?.label,
+      username: notPassType && '',
+    },
+    secureJsonFields: {
+      ...options.secureJsonFields,
+      token: notTokenType && false,
+      password: notPassType && false,
+    },
+    secureJsonData: {
+      ...options.secureJsonData,
+      token: notTokenType && '',
+      password: notPassType && '',
+    },
+  })
 }
 
 export const getSqlCompletionProvider: (args: any) => LanguageCompletionProvider =


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/117
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/116
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/118

- [x] if a bucket-name isn't supplied we can imply that the server is not iox backed and therefore get all table types (base tables is not implemented as a default by the [sqllite server test case](https://github.com/apache/arrow/blob/main/go/arrow/flight/flightsql/example/sqlite_server.go#L303))
- [x] if the auth type changes we must reset the token/pass state so its not still being set
- [x] the frontend needs to be able to send empty metadata to the backend so that it can overwrite a header that is no longer wanted - instead do the check for an empty key in the backend. 