### PR TITLE
fix: alerting locked state

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:-9.2.5}
+        grafana_version: ${GRAFANA_VERSION:-9.4.7}
     ports:
       - 3000:3000/tcp
     volumes:

--- a/src/components/BuilderView.tsx
+++ b/src/components/BuilderView.tsx
@@ -97,7 +97,8 @@ export function BuilderView({query, datasource, onChange, fromRawSql}: any) {
 
   useEffect(() => {
     if (column) {
-      handleColumnChange(column, setColumnValues, columnValues)
+      const copyColumns = [...columnValues]
+      handleColumnChange(column, setColumnValues, copyColumns)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [column])

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -47,13 +47,12 @@ export const prefixDB = (table: string, dbSchema: string) => {
 }
 
 export const handleColumnChange = (column: any, setColumnValues: any, columnValues: any) => {
-  let newColumnValues = [...columnValues]
-  const lastIndex = newColumnValues.length - 1
+  const lastIndex = columnValues.length - 1
   if (column.index === undefined) {
     column.index = lastIndex
   }
-  newColumnValues[column.index]['value'] = column?.value
-  setColumnValues(newColumnValues)
+  columnValues[column.index]['value'] = column?.value
+  setColumnValues(columnValues)
 }
 
 export const addColumns = (setColumnValues: any, columnValues: any) => {


### PR DESCRIPTION
closes https://github.com/influxdata/grafana-flightsql-datasource/issues/127

In grafana [v3.0.0](https://github.com/grafana/grafana/blob/main/CHANGELOG.md#930-beta1-2022-11-15) something changed about the alerting view state handling which caused column state to be locked and therefore unmodifiable but only on the alerting screen / not the plugin/dashboard view

This change spreads the column values prior to handing into the function and therefore ensures it's in a mutable state

Confirmed this fixes the bug in the alerting view for the latest version of grafana 9.4.7 - the dashboard view works in either case

also updates the plugin version for a bugfix release

also updates our docker image to grafana 9.4.7 for local development