### PR TITLE
fix: query help examples quoting and casting

### DIFF
--- a/src/components/QueryHelp.tsx
+++ b/src/components/QueryHelp.tsx
@@ -15,34 +15,34 @@ export const QueryHelp = () => (
     <div>
       <h3>Supported Macros:</h3>
       <li>
-        $__dateBin(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, timestamp
-        &rsquo;1970-01-01T00:00:00Z&rsquo;)
+        $__dateBin(time) -&gt; date_bin(interval &apos;30 second&apos;, time, timestamp
+        &apos;1970-01-01T00:00:00Z&apos;)
       </li>
       <li>
-        $__dateBinAlias(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, timestamp
-        &rsquo;1970-01-01T00:00:00Z&rsquo;) as time_binned
+        $__dateBinAlias(time) -&gt; date_bin(interval &apos;30 second&apos;, time, timestamp
+        &apos;1970-01-01T00:00:00Z&apos;) as time_binned
       </li>
-      <li>$__interval -&gt; interval &rsquo;30 second&rsquo;</li>
+      <li>$__interval -&gt; interval &apos;30 second&apos;</li>
       <li>
-        $__timeFilter() -&gt; time &gt;= &rsquo;2023-01-26T16:24:39Z&rsquo; AND time &lt;=
-        &rsquo;2023-01-26T17:24:39Z&rsquo;
+        $__timeFilter() -&gt; time &gt;= &apos;2023-01-26T16:24:39Z&apos; AND time &lt;=
+        &apos;2023-01-26T17:24:39Z&apos;
       </li>
-      <li>$__timeFrom -&gt; cast(&rsquo;2023-01-01T00:00:00Z&rsquo; as timestamp)</li>
+      <li>$__timeFrom -&gt; cast(&apos;2023-01-01T00:00:00Z&apos; as timestamp)</li>
       <li>
-        $__timeGroup(time, hour) -&gt; datepart(&rsquo;minute&rsquo;, time),datepart(&rsquo;hour&rsquo;,
-        time),datepart(&rsquo;day&rsquo;, time),datepart(&rsquo;month&rsquo;, time),datepart(&rsquo;year&rsquo;, time);
-      </li>
-      <li>
-        $__timeGroupAlias(time, minute) -&gt; datepart(&rsquo;minute&rsquo;, time) as
-        time_minute,datepart(&rsquo;hour&rsquo;, time) as time_hour,datepart(&rsquo;day&rsquo;, time) as
-        time_day,datepart(&rsquo;month&rsquo;, time) as time_month, datepart(&rsquo;year&rsquo;, time) as time_year
+        $__timeGroup(time, hour) -&gt; datepart(&apos;minute&apos;, time),datepart(&apos;hour&apos;,
+        time),datepart(&apos;day&apos;, time),datepart(&apos;month&apos;, time),datepart(&apos;year&apos;, time);
       </li>
       <li>
-        $__timeRange -&gt; time &gt;= &rsquo;2023-01 01T00:00:00Z&rsquo; and time &lt;=
-        &rsquo;2023-01-01T01:00:00Z&rsquo;
+        $__timeGroupAlias(time, minute) -&gt; datepart(&apos;minute&apos;, time) as
+        time_minute,datepart(&apos;hour&apos;, time) as time_hour,datepart(&apos;day&apos;, time) as
+        time_day,datepart(&apos;month&apos;, time) as time_month, datepart(&apos;year&apos;, time) as time_year
       </li>
-      <li>$__timeRangeFrom(time) -&gt; time &gt;= &rsquo;2023-01-01T00:00:00Z&rsquo;</li>
-      <li> $__timeRangeTo(time) -&gt; time &lt;= &rsquo;2023-01-01T01:00:00Z&rsquo;</li>
+      <li>
+        $__timeRange -&gt; time &gt;= &apos;2023-01 01T00:00:00Z&apos; and time &lt;=
+        &apos;2023-01-01T01:00:00Z&apos;
+      </li>
+      <li>$__timeRangeFrom(time) -&gt; time &gt;= &apos;2023-01-01T00:00:00Z&apos;</li>
+      <li> $__timeRangeTo(time) -&gt; time &lt;= &apos;2023-01-01T01:00:00Z&apos;</li>
       <li>$__timeTo(time) -&gt; cast(time as timestamp)</li>
     </div>
   </Alert>

--- a/src/components/QueryHelp.tsx
+++ b/src/components/QueryHelp.tsx
@@ -15,11 +15,11 @@ export const QueryHelp = () => (
     <div>
       <h3>Supported Macros:</h3>
       <li>
-        $__dateBin(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, interval
+        $__dateBin(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, timestamp
         &rsquo;1970-01-01T00:00:00Z&rsquo;)
       </li>
       <li>
-        $__dateBinAlias(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, interval
+        $__dateBinAlias(time) -&gt; date_bin(interval &rsquo;30 second&rsquo;, time, timestamp
         &rsquo;1970-01-01T00:00:00Z&rsquo;) as time_binned
       </li>
       <li>$__interval -&gt; interval &rsquo;30 second&rsquo;</li>


### PR DESCRIPTION
The casting within `date_bin` examples is incorrect - the examples attempt to cast a timestamp to an `interval`.

The quoting used in most of the examples used a right single quote (`&rsquo;`) which isn't valid for use in queries.