### PR TITLE
fix: release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline


### PR DESCRIPTION
```
Error: ../../../go/pkg/mod/github.com/getkin/kin-openapi@v0.120.0/openapi3/schema.go:1989:32: compiledPatterns.CompareAndSwap undefined (type sync.Map has no field or method CompareAndSwap)
note: module requires Go 1.20
```