### PR TITLE
fix: update go release version for plugin validator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Install dependencies
         run: yarn install --immutable --prefer-offline


### PR DESCRIPTION
the grafana plugin validator only works against go 1.21

```
Run git clone https://github.com/grafana/plugin-validator
Cloning into 'plugin-validator'...
~/work/grafana-flightsql-datasource/grafana-flightsql-datasource/plugin-validator/pkg/cmd/plugincheck2 ~/work/grafana-flightsql-datasource/grafana-flightsql-datasource
go: errors parsing go.mod:
/home/runner/work/grafana-flightsql-datasource/grafana-flightsql-datasource/plugin-validator/go.mod:3: invalid go version '1.21.8': must match format 1.23
/home/runner/work/grafana-flightsql-datasource/grafana-flightsql-datasource/plugin-validator/go.mod:5: unknown directive: toolchain
```